### PR TITLE
feat(core): add optional files glob filter to SEC-001

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+## Summary
+-
+
+Closes #

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "picomatch": "^4.0.3",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4",
+    "@types/picomatch": "^4.0.2",
     "@types/unist": "^3.0.3"
   }
 }

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -20,7 +20,7 @@ const registry: Record<string, RuleFactory> = {
   str001: (options) =>
     str001(options as { files: string[] }),
   sec001: (options) =>
-    sec001(options as { sections: string[] }),
+    sec001(options as { sections: string[]; files?: string }),
 };
 
 export function resolveRule(

--- a/packages/core/src/rules/sec-001.test.ts
+++ b/packages/core/src/rules/sec-001.test.ts
@@ -39,4 +39,45 @@ describe("SEC-001", () => {
     const messages = runRules([rule], doc, "test.md");
     expect(messages).toHaveLength(1);
   });
+
+  it("skips files not matching the files pattern", () => {
+    const doc = parseDocument("# Unrelated");
+    const rule = sec001({
+      sections: ["Overview", "Requirements"],
+      files: "docs/**/table_*.md",
+    });
+    const messages = runRules([rule], doc, "docs/zones/auth/requirements.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("checks files matching the files pattern", () => {
+    const doc = parseDocument("# Unrelated");
+    const rule = sec001({
+      sections: ["Overview", "Requirements"],
+      files: "docs/**/table_*.md",
+    });
+    const messages = runRules([rule], doc, "docs/zones/auth/table_users.md");
+    expect(messages).toHaveLength(2);
+  });
+
+  it("checks files matching the files pattern with absolute path", () => {
+    const doc = parseDocument("# Unrelated");
+    const rule = sec001({
+      sections: ["Overview"],
+      files: "docs/**/table_*.md",
+    });
+    const messages = runRules(
+      [rule],
+      doc,
+      "/Users/someone/project/docs/zones/auth/table_users.md",
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it("checks all files when files option is not set", () => {
+    const doc = parseDocument("# Unrelated");
+    const rule = sec001({ sections: ["Overview"] });
+    const messages = runRules([rule], doc, "anything.md");
+    expect(messages).toHaveLength(1);
+  });
 });

--- a/packages/core/src/rules/sec-001.ts
+++ b/packages/core/src/rules/sec-001.ts
@@ -1,15 +1,25 @@
+import picomatch from "picomatch";
 import type { Rule } from "../rule.js";
 
 export interface Sec001Options {
   sections: string[];
+  files?: string;
 }
 
 export function sec001(options: Sec001Options): Rule {
+  const isMatch = options.files
+    ? picomatch(`**/${options.files}`)
+    : null;
+
   return {
     id: "SEC-001",
     description: "Required sections must exist in the document",
     severity: "error",
     check: (context) => {
+      if (isMatch && !isMatch(context.filePath)) {
+        return;
+      }
+
       for (const section of options.sections) {
         if (!context.document.sections.includes(section)) {
           context.report({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
 
   packages/core:
     dependencies:
+      picomatch:
+        specifier: ^4.0.3
+        version: 4.0.3
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -51,6 +54,9 @@ importers:
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
+      '@types/picomatch':
+        specifier: ^4.0.2
+        version: 4.0.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -404,6 +410,9 @@ packages:
 
   '@types/node@25.3.3':
     resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
+
+  '@types/picomatch@4.0.2':
+    resolution: {integrity: sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1397,6 +1406,8 @@ snapshots:
   '@types/node@25.3.3':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/picomatch@4.0.2': {}
 
   '@types/unist@3.0.3': {}
 


### PR DESCRIPTION
## Summary
- Add optional `files` glob parameter to SEC-001 for scoping section checks to specific file patterns
- Use `picomatch` for glob matching (supports both relative and absolute paths)
- Backwards compatible: omitting `files` applies the rule to all files
- Add GitHub PR template

Closes #6