### PR TITLE
feat(core): add TBL-006 and cross-file rule architecture

### DIFF
--- a/packages/cli/src/lint.ts
+++ b/packages/cli/src/lint.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import { relative } from "node:path";
 import { glob } from "glob";
 import { parseDocument, runRules, resolveRule } from "@contextlint/core";
-import type { LintMessage } from "@contextlint/core";
+import type { LintMessage, ParsedDocument } from "@contextlint/core";
 import type { ContextlintConfig } from "./config.js";
 
 export interface FileLintResult {
@@ -27,6 +27,13 @@ export async function lintFiles(
 
   const projectFiles = files.map((f) => relative(cwd, f));
 
+  // Parse all files upfront (shared by document and project rules)
+  const documents = new Map<string, ParsedDocument>();
+  for (const filePath of files) {
+    const content = readFileSync(filePath, "utf-8");
+    documents.set(filePath, parseDocument(content));
+  }
+
   const results: FileLintResult[] = [];
 
   // Run project-scoped rules once
@@ -34,6 +41,7 @@ export async function lintFiles(
     const emptyDoc = parseDocument("");
     const messages = runRules(projectRules, emptyDoc, "<project>", {
       projectFiles,
+      documents,
     });
     if (messages.length > 0) {
       results.push({ filePath: "<project>", messages });
@@ -42,8 +50,7 @@ export async function lintFiles(
 
   // Run document-scoped rules per file
   for (const filePath of files) {
-    const content = readFileSync(filePath, "utf-8");
-    const document = parseDocument(content);
+    const document = documents.get(filePath)!;
     const messages = runRules(docRules, document, filePath);
     results.push({ filePath, messages });
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,4 +28,7 @@ export type { Sec001Options } from "./rules/sec-001.js";
 export { tbl004 } from "./rules/tbl-004.js";
 export type { Tbl004Options } from "./rules/tbl-004.js";
 
+export { tbl006 } from "./rules/tbl-006.js";
+export type { Tbl006Options } from "./rules/tbl-006.js";
+
 export { resolveRule } from "./registry.js";

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -5,6 +5,7 @@ import { tbl003 } from "./rules/tbl-003.js";
 import { tbl004 } from "./rules/tbl-004.js";
 import { str001 } from "./rules/str-001.js";
 import { sec001 } from "./rules/sec-001.js";
+import { tbl006 } from "./rules/tbl-006.js";
 
 type RuleFactory = (options?: Record<string, unknown>) => Rule;
 
@@ -21,6 +22,8 @@ const registry: Record<string, RuleFactory> = {
     str001(options as { files: string[] }),
   sec001: (options) =>
     sec001(options as { sections: string[]; files?: string }),
+  tbl006: (options) =>
+    tbl006(options as { files: string; column: string; idPattern?: string }),
 };
 
 export function resolveRule(

--- a/packages/core/src/rule.ts
+++ b/packages/core/src/rule.ts
@@ -13,6 +13,7 @@ export interface RuleContext {
   document: ParsedDocument;
   filePath: string;
   projectFiles?: string[];
+  documents?: Map<string, ParsedDocument>;
   report: (msg: Omit<LintMessage, "ruleId">) => void;
 }
 
@@ -26,6 +27,7 @@ export interface Rule {
 
 export interface RunOptions {
   projectFiles?: string[];
+  documents?: Map<string, ParsedDocument>;
 }
 
 export function runRules(
@@ -41,6 +43,7 @@ export function runRules(
       document,
       filePath,
       projectFiles: options?.projectFiles,
+      documents: options?.documents,
       report: (msg) => {
         messages.push({ ruleId: rule.id, ...msg });
       },

--- a/packages/core/src/rules/tbl-006.test.ts
+++ b/packages/core/src/rules/tbl-006.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { parseDocument, runRules } from "../index.js";
+import type { ParsedDocument } from "../index.js";
+import { tbl006 } from "./tbl-006.js";
+
+function lint(
+  filesMap: Record<string, string>,
+  options: { files: string; column: string; idPattern?: string },
+) {
+  const documents = new Map<string, ParsedDocument>();
+  for (const [path, content] of Object.entries(filesMap)) {
+    documents.set(path, parseDocument(content));
+  }
+
+  const rule = tbl006(options);
+  return runRules([rule], parseDocument(""), "<project>", {
+    documents,
+  });
+}
+
+describe("TBL-006", () => {
+  it("passes when all IDs are unique across files", () => {
+    const messages = lint(
+      {
+        "docs/file1.md": "| ID |\n|---|\n| REQ-01 |",
+        "docs/file2.md": "| ID |\n|---|\n| REQ-02 |",
+      },
+      { files: "docs/**/*.md", column: "ID" },
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("reports duplicate IDs across files", () => {
+    const messages = lint(
+      {
+        "docs/file1.md": "| ID |\n|---|\n| REQ-01 |",
+        "docs/file2.md": "| ID |\n|---|\n| REQ-01 |",
+      },
+      { files: "docs/**/*.md", column: "ID" },
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].ruleId).toBe("TBL-006");
+    expect(messages[0].message).toContain("REQ-01");
+    expect(messages[0].message).toContain("docs/file1.md");
+  });
+
+  it("reports duplicate IDs within the same file", () => {
+    const messages = lint(
+      {
+        "docs/file1.md": "| ID |\n|---|\n| REQ-01 |\n| REQ-01 |",
+      },
+      { files: "docs/**/*.md", column: "ID" },
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain("REQ-01");
+  });
+
+  it("only checks files matching the files pattern", () => {
+    const messages = lint(
+      {
+        "docs/file1.md": "| ID |\n|---|\n| REQ-01 |",
+        "other/file2.md": "| ID |\n|---|\n| REQ-01 |",
+      },
+      { files: "docs/**/*.md", column: "ID" },
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("only checks values matching idPattern", () => {
+    const messages = lint(
+      {
+        "docs/file1.md": "| ID |\n|---|\n| REQ-01 |\n| NOTE-1 |",
+        "docs/file2.md": "| ID |\n|---|\n| REQ-02 |\n| NOTE-1 |",
+      },
+      { files: "docs/**/*.md", column: "ID", idPattern: "^REQ-" },
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("skips tables without the specified column", () => {
+    const messages = lint(
+      {
+        "docs/file1.md": "| Name |\n|---|\n| Alice |",
+        "docs/file2.md": "| Name |\n|---|\n| Alice |",
+      },
+      { files: "docs/**/*.md", column: "ID" },
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("skips empty cell values", () => {
+    const messages = lint(
+      {
+        "docs/file1.md": "| ID |\n|---|\n|  |",
+        "docs/file2.md": "| ID |\n|---|\n|  |",
+      },
+      { files: "docs/**/*.md", column: "ID" },
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("does nothing when documents is not provided", () => {
+    const rule = tbl006({ files: "docs/**/*.md", column: "ID" });
+    const messages = runRules([rule], parseDocument(""), "<project>");
+    expect(messages).toEqual([]);
+  });
+});

--- a/packages/core/src/rules/tbl-006.ts
+++ b/packages/core/src/rules/tbl-006.ts
@@ -1,0 +1,61 @@
+import picomatch from "picomatch";
+import type { Rule } from "../rule.js";
+
+export interface Tbl006Options {
+  files: string;
+  column: string;
+  idPattern?: string;
+}
+
+export function tbl006(options: Tbl006Options): Rule {
+  const isMatch = picomatch(`**/${options.files}`);
+  const idRegex = options.idPattern ? new RegExp(options.idPattern) : null;
+
+  return {
+    id: "TBL-006",
+    description: "IDs in a specified column must be unique across all matched files",
+    severity: "error",
+    scope: "project",
+    check: (context) => {
+      if (!context.documents) {
+        return;
+      }
+
+      // Collect all IDs across matched files: id -> { filePath, line }
+      const seen = new Map<string, { filePath: string; line: number }>();
+
+      for (const [filePath, doc] of context.documents) {
+        if (!isMatch(filePath)) {
+          continue;
+        }
+
+        for (const table of doc.tables) {
+          if (!table.headers.includes(options.column)) {
+            continue;
+          }
+
+          for (const row of table.rows) {
+            const value = row[options.column];
+            if (!value) {
+              continue;
+            }
+            if (idRegex && !idRegex.test(value)) {
+              continue;
+            }
+
+            const existing = seen.get(value);
+            if (existing) {
+              context.report({
+                severity: "error",
+                message: `ID "${value}" is already defined in ${existing.filePath}:${existing.line}`,
+                line: table.line,
+              });
+            } else {
+              seen.set(value, { filePath, line: table.line });
+            }
+          }
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add `documents: Map<string, ParsedDocument>` to `RuleContext` / `RunOptions` for cross-file data access
- Refactor `lint.ts` to parse all files upfront and share results between document and project scoped rules
- Implement TBL-006: validate that IDs in a specified column are unique across all matched files
- Support optional `idPattern` filter to scope which values are treated as IDs

Closes #5