### PR TITLE
feat(core): add REF-002 ID traceability validation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,4 +31,7 @@ export type { Tbl004Options } from "./rules/tbl-004.js";
 export { tbl006 } from "./rules/tbl-006.js";
 export type { Tbl006Options } from "./rules/tbl-006.js";
 
+export { ref002 } from "./rules/ref-002.js";
+export type { Ref002Options } from "./rules/ref-002.js";
+
 export { resolveRule } from "./registry.js";

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -15,6 +15,7 @@ export interface ParsedTable {
 export interface ParsedDocument {
   tables: ParsedTable[];
   sections: string[];
+  content: string;
 }
 
 function extractText(node: Node): string {
@@ -76,5 +77,6 @@ export function parseDocument(content: string): ParsedDocument {
   return {
     tables,
     sections: headings.map((h) => h.text),
+    content,
   };
 }

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -6,6 +6,7 @@ import { tbl004 } from "./rules/tbl-004.js";
 import { str001 } from "./rules/str-001.js";
 import { sec001 } from "./rules/sec-001.js";
 import { tbl006 } from "./rules/tbl-006.js";
+import { ref002 } from "./rules/ref-002.js";
 
 type RuleFactory = (options?: Record<string, unknown>) => Rule;
 
@@ -24,6 +25,15 @@ const registry: Record<string, RuleFactory> = {
     sec001(options as { sections: string[]; files?: string }),
   tbl006: (options) =>
     tbl006(options as { files: string; column: string; idPattern?: string }),
+  ref002: (options) =>
+    ref002(
+      options as {
+        definitions: string;
+        references: string[];
+        idColumn: string;
+        idPattern: string;
+      },
+    ),
 };
 
 export function resolveRule(

--- a/packages/core/src/rules/ref-002.test.ts
+++ b/packages/core/src/rules/ref-002.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { parseDocument, runRules } from "../index.js";
+import type { ParsedDocument } from "../index.js";
+import { ref002 } from "./ref-002.js";
+
+const defaultOptions = {
+  definitions: "docs/zones/*/requirements.md",
+  references: ["docs/zones/**/table_*.md", "docs/zones/**/spec_*.md"],
+  idColumn: "ID",
+  idPattern: "^REQ-",
+};
+
+function lint(
+  filesMap: Record<string, string>,
+  options = defaultOptions,
+) {
+  const documents = new Map<string, ParsedDocument>();
+  for (const [path, content] of Object.entries(filesMap)) {
+    documents.set(path, parseDocument(content));
+  }
+
+  const rule = ref002(options);
+  return runRules([rule], parseDocument(""), "<project>", { documents });
+}
+
+describe("REF-002", () => {
+  it("passes when all defined IDs are referenced and all references exist", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Name |\n|---|---|\n| REQ-AUTH-01 | Login |",
+      "docs/zones/auth/table_users.md":
+        "| ID | Ref |\n|---|---|\n| TBL-01 | REQ-AUTH-01 |",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("reports dangling reference (referenced but not defined)", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Name |\n|---|---|\n| REQ-AUTH-01 | Login |",
+      "docs/zones/auth/table_users.md":
+        "| ID | Ref |\n|---|---|\n| TBL-01 | REQ-AUTH-99 |",
+    });
+    const dangling = messages.filter((m) => m.severity === "error");
+    const orphan = messages.filter((m) => m.severity === "warning");
+    expect(dangling).toHaveLength(1);
+    expect(dangling[0].message).toContain("REQ-AUTH-99");
+    expect(dangling[0].message).toContain("not defined");
+    expect(orphan).toHaveLength(1);
+    expect(orphan[0].message).toContain("REQ-AUTH-01");
+    expect(orphan[0].message).toContain("never referenced");
+  });
+
+  it("reports orphan definition (defined but not referenced)", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Name |\n|---|---|\n| REQ-AUTH-01 | Login |\n| REQ-AUTH-02 | Logout |",
+      "docs/zones/auth/table_users.md":
+        "| ID | Ref |\n|---|---|\n| TBL-01 | REQ-AUTH-01 |",
+    });
+    expect(messages).toHaveLength(1);
+    expect(messages[0].severity).toBe("warning");
+    expect(messages[0].message).toContain("REQ-AUTH-02");
+  });
+
+  it("detects references in prose text", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Name |\n|---|---|\n| REQ-AUTH-01 | Login |",
+      "docs/zones/auth/spec_login.md":
+        "# Login Spec\n\nThis implements REQ-AUTH-01 from the requirements.",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("detects dangling references in prose text", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Name |\n|---|---|\n| REQ-AUTH-01 | Login |",
+      "docs/zones/auth/spec_login.md":
+        "# Login Spec\n\nSee REQ-AUTH-99 for details.",
+    });
+    const dangling = messages.filter((m) => m.severity === "error");
+    expect(dangling).toHaveLength(1);
+    expect(dangling[0].message).toContain("REQ-AUTH-99");
+  });
+
+  it("only scans definition files matching the definitions pattern", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Name |\n|---|---|\n| REQ-AUTH-01 | Login |",
+      "docs/other/notes.md":
+        "| ID | Name |\n|---|---|\n| REQ-OTHER-01 | Note |",
+      "docs/zones/auth/table_users.md":
+        "| ID | Ref |\n|---|---|\n| TBL-01 | REQ-AUTH-01 |",
+    });
+    // REQ-OTHER-01 is not in a definitions file, so no orphan warning for it
+    expect(messages).toEqual([]);
+  });
+
+  it("only scans reference files matching the references pattern", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Name |\n|---|---|\n| REQ-AUTH-01 | Login |",
+      "docs/zones/auth/notes.md":
+        "| Ref |\n|---|\n| REQ-AUTH-01 |",
+    });
+    // notes.md doesn't match table_* or spec_* pattern, so REQ-AUTH-01 is orphaned
+    expect(messages).toHaveLength(1);
+    expect(messages[0].severity).toBe("warning");
+  });
+
+  it("does nothing when documents is not provided", () => {
+    const rule = ref002(defaultOptions);
+    const messages = runRules([rule], parseDocument(""), "<project>");
+    expect(messages).toEqual([]);
+  });
+});

--- a/packages/core/src/rules/ref-002.ts
+++ b/packages/core/src/rules/ref-002.ts
@@ -1,0 +1,101 @@
+import picomatch from "picomatch";
+import type { Rule } from "../rule.js";
+
+export interface Ref002Options {
+  definitions: string;
+  references: string[];
+  idColumn: string;
+  idPattern: string;
+}
+
+export function ref002(options: Ref002Options): Rule {
+  const isDefinition = picomatch(`**/${options.definitions}`);
+  const isReference = options.references.map((p) => picomatch(`**/${p}`));
+  const idRegex = new RegExp(options.idPattern);
+
+  function matchesReference(filePath: string): boolean {
+    return isReference.some((matcher) => matcher(filePath));
+  }
+
+  return {
+    id: "REF-002",
+    description:
+      "Validate that requirement IDs defined in definition files are referenced, and that IDs referenced elsewhere exist in definition files",
+    severity: "error",
+    scope: "project",
+    check: (context) => {
+      if (!context.documents) {
+        return;
+      }
+
+      // Collect defined IDs: id -> { filePath, line }
+      const defined = new Map<string, { filePath: string; line: number }>();
+      for (const [filePath, doc] of context.documents) {
+        if (!isDefinition(filePath)) {
+          continue;
+        }
+        for (const table of doc.tables) {
+          if (!table.headers.includes(options.idColumn)) {
+            continue;
+          }
+          for (const row of table.rows) {
+            const value = row[options.idColumn];
+            if (value && idRegex.test(value)) {
+              defined.set(value, { filePath, line: table.line });
+            }
+          }
+        }
+      }
+
+      // Collect referenced IDs from table columns and prose text
+      const referenced = new Set<string>();
+      for (const [filePath, doc] of context.documents) {
+        if (!matchesReference(filePath)) {
+          continue;
+        }
+
+        // From table columns
+        for (const table of doc.tables) {
+          for (const row of table.rows) {
+            for (const value of Object.values(row)) {
+              if (value && idRegex.test(value)) {
+                referenced.add(value);
+              }
+            }
+          }
+        }
+
+        // From prose text (split into tokens, strip punctuation, check pattern)
+        const tokens = doc.content.match(/\S+/g) ?? [];
+        for (const token of tokens) {
+          const cleaned = token.replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9]+$/g, "");
+          if (cleaned && idRegex.test(cleaned)) {
+            referenced.add(cleaned);
+          }
+        }
+      }
+
+      // Report dangling references (referenced but not defined)
+      for (const id of referenced) {
+        if (!defined.has(id)) {
+          context.report({
+            severity: "error",
+            message: `ID "${id}" is referenced but not defined in any definition file`,
+            line: 0,
+          });
+        }
+      }
+
+      // Report orphan definitions (defined but not referenced)
+      for (const [id, location] of defined) {
+        if (!referenced.has(id)) {
+          context.report({
+            severity: "warning",
+            message: `ID "${id}" is defined in ${location.filePath}:${location.line} but never referenced`,
+            line: 0,
+          });
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add `content` field to `ParsedDocument` for raw Markdown text access
- Implement REF-002: validate that defined IDs are referenced and referenced IDs exist
- Dangling reference (referenced but not defined) → error
- Orphan definition (defined but not referenced) → warning
- Scan both table columns and prose text for ID references (tokenize + strip punctuation)

Closes #3