### PR TITLE
feat(core): add REF-003 stability consistency validation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,4 +34,7 @@ export type { Tbl006Options } from "./rules/tbl-006.js";
 export { ref002 } from "./rules/ref-002.js";
 export type { Ref002Options } from "./rules/ref-002.js";
 
+export { ref003 } from "./rules/ref-003.js";
+export type { Ref003Options } from "./rules/ref-003.js";
+
 export { resolveRule } from "./registry.js";

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -7,6 +7,7 @@ import { str001 } from "./rules/str-001.js";
 import { sec001 } from "./rules/sec-001.js";
 import { tbl006 } from "./rules/tbl-006.js";
 import { ref002 } from "./rules/ref-002.js";
+import { ref003 } from "./rules/ref-003.js";
 
 type RuleFactory = (options?: Record<string, unknown>) => Rule;
 
@@ -32,6 +33,17 @@ const registry: Record<string, RuleFactory> = {
         references: string[];
         idColumn: string;
         idPattern: string;
+      },
+    ),
+  ref003: (options) =>
+    ref003(
+      options as {
+        stabilityColumn: string;
+        stabilityOrder: string[];
+        definitions: string;
+        references: string[];
+        idColumn?: string;
+        idPattern?: string;
       },
     ),
 };

--- a/packages/core/src/rules/ref-003.test.ts
+++ b/packages/core/src/rules/ref-003.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { parseDocument, runRules } from "../index.js";
+import type { ParsedDocument } from "../index.js";
+import { ref003 } from "./ref-003.js";
+
+const defaultOptions = {
+  stabilityColumn: "Stability",
+  stabilityOrder: ["draft", "review", "stable"],
+  definitions: "docs/zones/*/requirements.md",
+  references: ["docs/zones/**/table_*.md"],
+  idColumn: "ID",
+  idPattern: "^REQ-",
+};
+
+function lint(
+  filesMap: Record<string, string>,
+  options = defaultOptions,
+) {
+  const documents = new Map<string, ParsedDocument>();
+  for (const [path, content] of Object.entries(filesMap)) {
+    documents.set(path, parseDocument(content));
+  }
+
+  const rule = ref003(options);
+  return runRules([rule], parseDocument(""), "<project>", { documents });
+}
+
+describe("REF-003", () => {
+  it("passes when stability is consistent", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Stability |\n|---|---|\n| REQ-AUTH-01 | review |",
+      "docs/zones/auth/table_users.md":
+        "| ID | Ref | Stability |\n|---|---|---|\n| TBL-01 | REQ-AUTH-01 | review |",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("passes when reference has lower stability than definition", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Stability |\n|---|---|\n| REQ-AUTH-01 | stable |",
+      "docs/zones/auth/table_users.md":
+        "| ID | Ref | Stability |\n|---|---|---|\n| TBL-01 | REQ-AUTH-01 | draft |",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("warns when reference has higher stability than definition", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Stability |\n|---|---|\n| REQ-AUTH-01 | draft |",
+      "docs/zones/auth/table_users.md":
+        "| ID | Ref | Stability |\n|---|---|---|\n| TBL-01 | REQ-AUTH-01 | review |",
+    });
+    expect(messages).toHaveLength(1);
+    expect(messages[0].severity).toBe("warning");
+    expect(messages[0].message).toContain("REQ-AUTH-01");
+    expect(messages[0].message).toContain('"draft"');
+    expect(messages[0].message).toContain('"review"');
+  });
+
+  it("warns when stable references draft", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Stability |\n|---|---|\n| REQ-AUTH-01 | draft |",
+      "docs/zones/auth/table_users.md":
+        "| ID | Ref | Stability |\n|---|---|---|\n| TBL-01 | REQ-AUTH-01 | stable |",
+    });
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('"draft"');
+    expect(messages[0].message).toContain('"stable"');
+  });
+
+  it("handles multiple references in one row", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Stability |\n|---|---|\n| REQ-AUTH-01 | draft |\n| REQ-AUTH-02 | stable |",
+      "docs/zones/auth/table_users.md":
+        "| Ref1 | Ref2 | Stability |\n|---|---|---|\n| REQ-AUTH-01 | REQ-AUTH-02 | review |",
+    });
+    // REQ-AUTH-01 is draft, row is review → warning
+    // REQ-AUTH-02 is stable, row is review → ok
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain("REQ-AUTH-01");
+  });
+
+  it("skips rows without stability value", () => {
+    const messages = lint({
+      "docs/zones/auth/requirements.md":
+        "| ID | Stability |\n|---|---|\n| REQ-AUTH-01 | draft |",
+      "docs/zones/auth/table_users.md":
+        "| ID | Ref | Stability |\n|---|---|---|\n| TBL-01 | REQ-AUTH-01 |  |",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("works with custom stability column name", () => {
+    const messages = lint(
+      {
+        "docs/zones/auth/requirements.md":
+          "| ID | 安定度 |\n|---|---|\n| REQ-AUTH-01 | draft |",
+        "docs/zones/auth/table_users.md":
+          "| ID | Ref | 安定度 |\n|---|---|---|\n| TBL-01 | REQ-AUTH-01 | stable |",
+      },
+      { ...defaultOptions, stabilityColumn: "安定度" },
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it("does nothing when documents is not provided", () => {
+    const rule = ref003(defaultOptions);
+    const messages = runRules([rule], parseDocument(""), "<project>");
+    expect(messages).toEqual([]);
+  });
+});

--- a/packages/core/src/rules/ref-003.ts
+++ b/packages/core/src/rules/ref-003.ts
@@ -1,0 +1,110 @@
+import picomatch from "picomatch";
+import type { Rule } from "../rule.js";
+
+export interface Ref003Options {
+  stabilityColumn: string;
+  stabilityOrder: string[];
+  definitions: string;
+  references: string[];
+  idColumn?: string;
+  idPattern?: string;
+}
+
+export function ref003(options: Ref003Options): Rule {
+  const isDefinition = picomatch(`**/${options.definitions}`);
+  const isReference = options.references.map((p) => picomatch(`**/${p}`));
+  const idColumn = options.idColumn ?? "ID";
+  const idRegex = options.idPattern ? new RegExp(options.idPattern) : null;
+
+  const stabilityRank = new Map<string, number>();
+  for (let i = 0; i < options.stabilityOrder.length; i++) {
+    stabilityRank.set(options.stabilityOrder[i], i);
+  }
+
+  function matchesReference(filePath: string): boolean {
+    return isReference.some((matcher) => matcher(filePath));
+  }
+
+  return {
+    id: "REF-003",
+    description:
+      "A document item's stability should not exceed the stability of items it depends on",
+    severity: "warning",
+    scope: "project",
+    check: (context) => {
+      if (!context.documents) {
+        return;
+      }
+
+      // Collect defined IDs with their stability: id -> { stability, filePath }
+      const definitions = new Map<
+        string,
+        { stability: string; filePath: string }
+      >();
+
+      for (const [filePath, doc] of context.documents) {
+        if (!isDefinition(filePath)) {
+          continue;
+        }
+        for (const table of doc.tables) {
+          if (
+            !table.headers.includes(idColumn) ||
+            !table.headers.includes(options.stabilityColumn)
+          ) {
+            continue;
+          }
+          for (const row of table.rows) {
+            const id = row[idColumn];
+            const stability = row[options.stabilityColumn];
+            if (!id || !stability) {
+              continue;
+            }
+            if (idRegex && !idRegex.test(id)) {
+              continue;
+            }
+            definitions.set(id, { stability, filePath });
+          }
+        }
+      }
+
+      // Check reference files for stability mismatches
+      for (const [filePath, doc] of context.documents) {
+        if (!matchesReference(filePath)) {
+          continue;
+        }
+        for (const table of doc.tables) {
+          if (!table.headers.includes(options.stabilityColumn)) {
+            continue;
+          }
+          for (const row of table.rows) {
+            const refStability = row[options.stabilityColumn];
+            if (!refStability || !stabilityRank.has(refStability)) {
+              continue;
+            }
+            const refRank = stabilityRank.get(refStability)!;
+
+            // Find referenced IDs in other cells of this row
+            for (const [col, value] of Object.entries(row)) {
+              if (col === options.stabilityColumn || !value) {
+                continue;
+              }
+              const def = definitions.get(value);
+              if (!def || !stabilityRank.has(def.stability)) {
+                continue;
+              }
+              const defRank = stabilityRank.get(def.stability)!;
+
+              if (refRank > defRank) {
+                context.report({
+                  severity: "warning",
+                  message: `Item "${value}" has stability "${def.stability}" in ${def.filePath}, but is referenced from a row with stability "${refStability}" in ${filePath}`,
+                  line: table.line,
+                });
+              }
+            }
+          }
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Implement REF-003: warn when a referencing item's stability exceeds the stability of items it depends on
- Configurable `stabilityColumn`, `stabilityOrder`, `definitions`, `references`, `idColumn`, `idPattern`
- Works for any status-driven document system (DNA, RFC, ADR, etc.)
- Severity: warning (stability mismatches may be intentional during development)

Closes #4