### PR TITLE
feat(core): add REF-001 broken relative link detection

### DIFF
--- a/packages/cli/src/lint.ts
+++ b/packages/cli/src/lint.ts
@@ -51,7 +51,7 @@ export async function lintFiles(
   // Run document-scoped rules per file
   for (const filePath of files) {
     const document = documents.get(filePath)!;
-    const messages = runRules(docRules, document, filePath);
+    const messages = runRules(docRules, document, filePath, { documents });
     results.push({ filePath, messages });
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { parseDocument } from "./parser.js";
-export type { ParsedTable, ParsedDocument } from "./parser.js";
+export type { ParsedLink, ParsedTable, ParsedDocument } from "./parser.js";
 
 export { runRules } from "./rule.js";
 export type {
@@ -30,6 +30,8 @@ export type { Tbl004Options } from "./rules/tbl-004.js";
 
 export { tbl006 } from "./rules/tbl-006.js";
 export type { Tbl006Options } from "./rules/tbl-006.js";
+
+export { ref001 } from "./rules/ref-001.js";
 
 export { ref002 } from "./rules/ref-002.js";
 export type { Ref002Options } from "./rules/ref-002.js";

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -2,7 +2,7 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
 import { visit } from "unist-util-visit";
-import type { Heading, Table, TableRow, Text } from "mdast";
+import type { Definition, Heading, Link, Table, TableRow, Text } from "mdast";
 import type { Node } from "unist";
 
 export interface ParsedTable {
@@ -12,9 +12,15 @@ export interface ParsedTable {
   rows: Record<string, string>[];
 }
 
+export interface ParsedLink {
+  url: string;
+  line: number;
+}
+
 export interface ParsedDocument {
   tables: ParsedTable[];
   sections: string[];
+  links: ParsedLink[];
   content: string;
 }
 
@@ -37,6 +43,7 @@ export function parseDocument(content: string): ParsedDocument {
 
   const headings: { text: string; line: number }[] = [];
   const tables: ParsedTable[] = [];
+  const links: ParsedLink[] = [];
 
   visit(tree, "heading", (node: Heading) => {
     headings.push({
@@ -74,9 +81,23 @@ export function parseDocument(content: string): ParsedDocument {
     tables.push({ line: tableLine, section, headers, rows });
   });
 
+  // Collect relative links (inline and reference-style)
+  visit(tree, "link", (node: Link) => {
+    if (!node.url.startsWith("http") && !node.url.startsWith("#")) {
+      links.push({ url: node.url, line: node.position?.start.line ?? 0 });
+    }
+  });
+
+  visit(tree, "definition", (node: Definition) => {
+    if (!node.url.startsWith("http") && !node.url.startsWith("#")) {
+      links.push({ url: node.url, line: node.position?.start.line ?? 0 });
+    }
+  });
+
   return {
     tables,
     sections: headings.map((h) => h.text),
+    links,
     content,
   };
 }

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -8,6 +8,7 @@ import { sec001 } from "./rules/sec-001.js";
 import { tbl006 } from "./rules/tbl-006.js";
 import { ref002 } from "./rules/ref-002.js";
 import { ref003 } from "./rules/ref-003.js";
+import { ref001 } from "./rules/ref-001.js";
 
 type RuleFactory = (options?: Record<string, unknown>) => Rule;
 
@@ -35,6 +36,7 @@ const registry: Record<string, RuleFactory> = {
         idPattern: string;
       },
     ),
+  ref001: () => ref001(),
   ref003: (options) =>
     ref003(
       options as {

--- a/packages/core/src/rules/ref-001.test.ts
+++ b/packages/core/src/rules/ref-001.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { parseDocument, runRules } from "../index.js";
+import type { ParsedDocument } from "../index.js";
+import { ref001 } from "./ref-001.js";
+
+function lint(currentFile: string, filesMap: Record<string, string>) {
+  const documents = new Map<string, ParsedDocument>();
+  for (const [path, content] of Object.entries(filesMap)) {
+    documents.set(path, parseDocument(content));
+  }
+
+  const rule = ref001();
+  const doc = documents.get(currentFile)!;
+  return runRules([rule], doc, currentFile, { documents });
+}
+
+describe("REF-001", () => {
+  it("passes when all link targets exist", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md": "[requirements](./requirements.md)",
+      "/project/docs/requirements.md": "# Requirements",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("reports a broken link", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md": "[old doc](./deleted.md)",
+    });
+    expect(messages).toHaveLength(1);
+    expect(messages[0].ruleId).toBe("REF-001");
+    expect(messages[0].severity).toBe("error");
+    expect(messages[0].message).toContain("./deleted.md");
+  });
+
+  it("resolves relative paths with parent directories", () => {
+    const messages = lint("/project/docs/zones/auth/spec.md", {
+      "/project/docs/zones/auth/spec.md":
+        "[users](../bulletin-board/table_contents.md)",
+      "/project/docs/zones/bulletin-board/table_contents.md": "# Contents",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("ignores external URLs", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md":
+        "[Google](https://google.com) and [HTTP](http://example.com)",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("ignores anchor-only links", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md": "[section](#some-section)",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("handles links with anchors to existing files", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md": "[section](./requirements.md#heading)",
+      "/project/docs/requirements.md": "# Requirements",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("reports links with anchors to non-existing files", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md": "[section](./missing.md#heading)",
+    });
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain("./missing.md#heading");
+  });
+
+  it("handles reference-style links", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md":
+        "See [ref][link1]\n\n[link1]: ./requirements.md",
+      "/project/docs/requirements.md": "# Requirements",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("reports multiple broken links", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md":
+        "[a](./missing1.md) and [b](./missing2.md)",
+    });
+    expect(messages).toHaveLength(2);
+  });
+
+  it("does nothing when documents is not provided", () => {
+    const rule = ref001();
+    const doc = parseDocument("[link](./file.md)");
+    const messages = runRules([rule], doc, "/project/test.md");
+    expect(messages).toEqual([]);
+  });
+});

--- a/packages/core/src/rules/ref-001.ts
+++ b/packages/core/src/rules/ref-001.ts
@@ -1,0 +1,35 @@
+import { resolve, dirname } from "node:path";
+import type { Rule } from "../rule.js";
+
+export function ref001(): Rule {
+  return {
+    id: "REF-001",
+    description: "All relative Markdown links must point to files that exist",
+    severity: "error",
+    check: (context) => {
+      if (!context.documents) {
+        return;
+      }
+
+      const allPaths = new Set(context.documents.keys());
+
+      for (const link of context.document.links) {
+        // Strip anchor fragment (e.g. ./file.md#section -> ./file.md)
+        const urlWithoutAnchor = link.url.split("#")[0];
+        if (!urlWithoutAnchor) {
+          continue;
+        }
+
+        const resolved = resolve(dirname(context.filePath), urlWithoutAnchor);
+
+        if (!allPaths.has(resolved)) {
+          context.report({
+            severity: "error",
+            message: `Link target "${link.url}" does not exist`,
+            line: link.line,
+          });
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Extend parser to extract relative Markdown links (inline and reference-style), filtering out external URLs and anchors
- Add `ParsedLink` type and `links` field to `ParsedDocument`
- Implement REF-001: report errors when relative link targets do not exist in the project
- Pass `documents` Map to document-scoped rules for cross-file awareness

Closes #2