### PR TITLE
feat: add REF-004 cross-zone dependency declaration rule

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,4 +39,7 @@ export type { Ref002Options } from "./rules/ref-002.js";
 export { ref003 } from "./rules/ref-003.js";
 export type { Ref003Options } from "./rules/ref-003.js";
 
+export { ref004 } from "./rules/ref-004.js";
+export type { Ref004Options } from "./rules/ref-004.js";
+
 export { resolveRule } from "./registry.js";

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -9,6 +9,7 @@ import { tbl006 } from "./rules/tbl-006.js";
 import { ref002 } from "./rules/ref-002.js";
 import { ref003 } from "./rules/ref-003.js";
 import { ref001 } from "./rules/ref-001.js";
+import { ref004 } from "./rules/ref-004.js";
 
 type RuleFactory = (options?: Record<string, unknown>) => Rule;
 
@@ -37,6 +38,13 @@ const registry: Record<string, RuleFactory> = {
       },
     ),
   ref001: () => ref001(),
+  ref004: (options) =>
+    ref004(
+      options as {
+        zonesDir: string;
+        dependencySection?: string;
+      },
+    ),
   ref003: (options) =>
     ref003(
       options as {

--- a/packages/core/src/rules/ref-004.test.ts
+++ b/packages/core/src/rules/ref-004.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { parseDocument, runRules } from "../index.js";
+import type { ParsedDocument } from "../index.js";
+import { ref004 } from "./ref-004.js";
+
+const defaultOptions = {
+  zonesDir: "docs/zones",
+};
+
+function lint(
+  currentFile: string,
+  filesMap: Record<string, string>,
+  options = defaultOptions,
+) {
+  const documents = new Map<string, ParsedDocument>();
+  for (const [path, content] of Object.entries(filesMap)) {
+    documents.set(path, parseDocument(content));
+  }
+
+  const rule = ref004(options);
+  const doc = documents.get(currentFile)!;
+  return runRules([rule], doc, currentFile, { documents });
+}
+
+describe("REF-004", () => {
+  it("passes when cross-zone reference is declared in Dependencies", () => {
+    const messages = lint(
+      "docs/zones/bulletin-board/spec_content.md",
+      {
+        "docs/zones/bulletin-board/spec_content.md":
+          "See [users](../auth/table_users.md)",
+        "docs/zones/bulletin-board/overview.md":
+          "# Overview\n\n## Dependencies\n\n| Zone | Reason |\n|---|---|\n| auth | User identity |",
+        "docs/zones/auth/table_users.md": "# Users",
+      },
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("reports undeclared cross-zone reference", () => {
+    const messages = lint(
+      "docs/zones/bulletin-board/spec_content.md",
+      {
+        "docs/zones/bulletin-board/spec_content.md":
+          "See [users](../auth/table_users.md)",
+        "docs/zones/bulletin-board/overview.md":
+          "# Overview\n\nNo dependencies section here.",
+        "docs/zones/auth/table_users.md": "# Users",
+      },
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].ruleId).toBe("REF-004");
+    expect(messages[0].message).toContain('"auth"');
+    expect(messages[0].message).toContain("Dependencies");
+  });
+
+  it("passes for same-zone references", () => {
+    const messages = lint(
+      "docs/zones/auth/spec_login.md",
+      {
+        "docs/zones/auth/spec_login.md":
+          "See [requirements](./requirements.md)",
+        "docs/zones/auth/requirements.md": "# Requirements",
+      },
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("reports multiple undeclared cross-zone references", () => {
+    const messages = lint(
+      "docs/zones/bulletin-board/spec_content.md",
+      {
+        "docs/zones/bulletin-board/spec_content.md":
+          "See [auth](../auth/table_users.md) and [infra](../infrastructure/design.md)",
+        "docs/zones/bulletin-board/overview.md":
+          "# Overview\n\n## Dependencies\n\n| Zone | Reason |\n|---|---|\n",
+        "docs/zones/auth/table_users.md": "# Users",
+        "docs/zones/infrastructure/design.md": "# Design",
+      },
+    );
+    expect(messages).toHaveLength(2);
+  });
+
+  it("passes for files outside zones directory", () => {
+    const messages = lint(
+      "docs/foundation/standards.md",
+      {
+        "docs/foundation/standards.md":
+          "See [overview](../zones/auth/overview.md)",
+        "docs/zones/auth/overview.md": "# Auth",
+      },
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("works with custom dependency section name", () => {
+    const messages = lint(
+      "docs/zones/bulletin-board/spec_content.md",
+      {
+        "docs/zones/bulletin-board/spec_content.md":
+          "See [users](../auth/table_users.md)",
+        "docs/zones/bulletin-board/overview.md":
+          "# Overview\n\n## 依存関係\n\n| Zone | Reason |\n|---|---|\n| auth | User identity |",
+        "docs/zones/auth/table_users.md": "# Users",
+      },
+      { zonesDir: "docs/zones", dependencySection: "依存関係" },
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("does nothing when documents is not provided", () => {
+    const rule = ref004(defaultOptions);
+    const doc = parseDocument("See [link](../auth/file.md)");
+    const messages = runRules([rule], doc, "docs/zones/bb/spec.md");
+    expect(messages).toEqual([]);
+  });
+});

--- a/packages/core/src/rules/ref-004.ts
+++ b/packages/core/src/rules/ref-004.ts
@@ -1,0 +1,103 @@
+import { resolve, dirname, relative } from "node:path";
+import type { Rule } from "../rule.js";
+
+export interface Ref004Options {
+  zonesDir: string;
+  dependencySection?: string;
+}
+
+export function ref004(options: Ref004Options): Rule {
+  const depSection = options.dependencySection ?? "Dependencies";
+
+  function getZone(filePath: string): string | null {
+    // Find zonesDir in the path and extract the first directory after it
+    const normalized = filePath.replace(/\\/g, "/");
+    const zonesDirNormalized = options.zonesDir.replace(/\\/g, "/");
+    const idx = normalized.indexOf(`/${zonesDirNormalized}/`);
+    if (idx === -1) {
+      // Try without leading slash (relative paths)
+      if (normalized.startsWith(`${zonesDirNormalized}/`)) {
+        const rest = normalized.slice(zonesDirNormalized.length + 1);
+        const zone = rest.split("/")[0];
+        return zone || null;
+      }
+      return null;
+    }
+    const rest = normalized.slice(idx + zonesDirNormalized.length + 2);
+    const zone = rest.split("/")[0];
+    return zone || null;
+  }
+
+  return {
+    id: "REF-004",
+    description:
+      "Cross-zone Markdown links must be backed by an explicit dependency declaration in the zone's overview",
+    severity: "error",
+    check: (context) => {
+      if (!context.documents) {
+        return;
+      }
+
+      const sourceZone = getZone(context.filePath);
+      if (!sourceZone) {
+        return;
+      }
+
+      // Find cross-zone links
+      const crossZoneTargets = new Set<string>();
+      for (const link of context.document.links) {
+        const resolved = resolve(
+          dirname(context.filePath),
+          link.url.split("#")[0],
+        );
+        const targetZone = getZone(resolved);
+        if (targetZone && targetZone !== sourceZone) {
+          crossZoneTargets.add(targetZone);
+        }
+      }
+
+      if (crossZoneTargets.size === 0) {
+        return;
+      }
+
+      // Find the overview.md for this zone and check Dependencies section
+      const declaredDeps = new Set<string>();
+      for (const [filePath, doc] of context.documents) {
+        const zone = getZone(filePath);
+        if (zone !== sourceZone) {
+          continue;
+        }
+        if (!filePath.replace(/\\/g, "/").endsWith("/overview.md")) {
+          continue;
+        }
+
+        // Check if Dependencies section exists and collect declared zones
+        if (doc.sections.includes(depSection)) {
+          for (const table of doc.tables) {
+            if (table.section !== depSection) {
+              continue;
+            }
+            for (const row of table.rows) {
+              for (const value of Object.values(row)) {
+                if (value) {
+                  declaredDeps.add(value.trim());
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Report undeclared cross-zone dependencies
+      for (const targetZone of crossZoneTargets) {
+        if (!declaredDeps.has(targetZone)) {
+          context.report({
+            severity: "error",
+            message: `Cross-zone reference to "${targetZone}" zone, but "${targetZone}" is not listed in the "${depSection}" section of ${sourceZone}/overview.md`,
+            line: 0,
+          });
+        }
+      }
+    },
+  };
+}

--- a/packages/presets/dna/src/index.test.ts
+++ b/packages/presets/dna/src/index.test.ts
@@ -42,7 +42,7 @@ describe("createConfig", () => {
     mkdirSync(join(tmp, "docs", "zones", "infra"), { recursive: true });
 
     const config = createConfig(tmp);
-    expect(config.rules).toHaveLength(5);
+    expect(config.rules).toHaveLength(6);
 
     const str001 = config.rules[4];
     expect(str001.rule).toBe("str001");
@@ -54,6 +54,10 @@ describe("createConfig", () => {
         "docs/zones/infra/requirements.md",
       ],
     });
+
+    const ref004 = config.rules[5];
+    expect(ref004.rule).toBe("ref004");
+    expect(ref004.options).toEqual({ zonesDir: "docs/zones" });
   });
 
   it("ignores files in zones directory (only directories)", () => {

--- a/packages/presets/dna/src/index.ts
+++ b/packages/presets/dna/src/index.ts
@@ -45,6 +45,12 @@ export function createConfig(cwd: string): PresetConfig {
       rule: "str001",
       options: { files },
     });
+
+    // Cross-zone dependency declaration check
+    rules.push({
+      rule: "ref004",
+      options: { zonesDir: "docs/zones" },
+    });
   }
 
   return { rules };


### PR DESCRIPTION
## Summary
- Implement REF-004: validate that cross-zone Markdown links are backed by an explicit dependency declaration in the zone's overview.md
- Configurable `zonesDir` and `dependencySection` (defaults to "Dependencies")
- Register REF-004 in `preset-dna` config when zones are detected

Closes #8