### PR TITLE
feat(core): add files option to TBL-001 through TBL-004

### DIFF
--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -15,13 +15,13 @@ type RuleFactory = (options?: Record<string, unknown>) => Rule;
 
 const registry: Record<string, RuleFactory> = {
   tbl001: (options) =>
-    tbl001(options as { requiredColumns: string[] }),
+    tbl001(options as { requiredColumns: string[]; files?: string }),
   tbl002: (options) =>
-    tbl002(options as { columns?: string[] } | undefined),
+    tbl002(options as { columns?: string[]; files?: string } | undefined),
   tbl003: (options) =>
-    tbl003(options as { column: string; values: string[] }),
+    tbl003(options as { column: string; values: string[]; files?: string }),
   tbl004: (options) =>
-    tbl004(options as { column: string; pattern: string }),
+    tbl004(options as { column: string; pattern: string; files?: string }),
   str001: (options) =>
     str001(options as { files: string[] }),
   sec001: (options) =>

--- a/packages/core/src/rules/tbl-001.test.ts
+++ b/packages/core/src/rules/tbl-001.test.ts
@@ -48,4 +48,40 @@ describe("TBL-001: required columns", () => {
     expect(messages).toHaveLength(1);
     expect(messages[0].message).toContain("ID");
   });
+
+  it("skips files not matching the files pattern", () => {
+    const md = `
+| Name | Age |
+|------|-----|
+| Alice | 30 |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID"], files: "**/requirements.md" });
+    const messages = runRules([rule], doc, "docs/overview.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("checks files matching the files pattern", () => {
+    const md = `
+| Name | Age |
+|------|-----|
+| Alice | 30 |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID"], files: "**/requirements.md" });
+    const messages = runRules([rule], doc, "docs/requirements.md");
+    expect(messages).toHaveLength(1);
+  });
+
+  it("checks all files when files option is not set", () => {
+    const md = `
+| Name | Age |
+|------|-----|
+| Alice | 30 |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID"] });
+    const messages = runRules([rule], doc, "docs/anything.md");
+    expect(messages).toHaveLength(1);
+  });
 });

--- a/packages/core/src/rules/tbl-001.ts
+++ b/packages/core/src/rules/tbl-001.ts
@@ -1,15 +1,23 @@
+import picomatch from "picomatch";
 import type { Rule } from "../rule.js";
 
 export interface Tbl001Options {
   requiredColumns: string[];
+  files?: string;
 }
 
 export function tbl001(options: Tbl001Options): Rule {
+  const isMatch = options.files ? picomatch(`**/${options.files}`) : null;
+
   return {
     id: "TBL-001",
     description: "Required columns must exist in tables",
     severity: "error",
     check: (context) => {
+      if (isMatch && !isMatch(context.filePath)) {
+        return;
+      }
+
       for (const table of context.document.tables) {
         for (const col of options.requiredColumns) {
           if (!table.headers.includes(col)) {

--- a/packages/core/src/rules/tbl-002.test.ts
+++ b/packages/core/src/rules/tbl-002.test.ts
@@ -68,4 +68,28 @@ describe("TBL-002: empty cell check", () => {
     const messages = runRules([rule], doc, "test.md");
     expect(messages).toHaveLength(0);
   });
+
+  it("skips files not matching the files pattern", () => {
+    const md = `
+| ID | Status |
+|----|--------|
+| 1  |        |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl002({ columns: ["Status"], files: "**/requirements.md" });
+    const messages = runRules([rule], doc, "docs/overview.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("checks files matching the files pattern", () => {
+    const md = `
+| ID | Status |
+|----|--------|
+| 1  |        |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl002({ columns: ["Status"], files: "**/requirements.md" });
+    const messages = runRules([rule], doc, "docs/requirements.md");
+    expect(messages).toHaveLength(1);
+  });
 });

--- a/packages/core/src/rules/tbl-002.ts
+++ b/packages/core/src/rules/tbl-002.ts
@@ -1,15 +1,23 @@
+import picomatch from "picomatch";
 import type { Rule } from "../rule.js";
 
 export interface Tbl002Options {
   columns?: string[];
+  files?: string;
 }
 
 export function tbl002(options?: Tbl002Options): Rule {
+  const isMatch = options?.files ? picomatch(`**/${options.files}`) : null;
+
   return {
     id: "TBL-002",
     description: "Table cells must not be empty",
     severity: "warning",
     check: (context) => {
+      if (isMatch && !isMatch(context.filePath)) {
+        return;
+      }
+
       for (const table of context.document.tables) {
         const targetColumns =
           options?.columns?.filter((c) => table.headers.includes(c)) ??

--- a/packages/core/src/rules/tbl-003.test.ts
+++ b/packages/core/src/rules/tbl-003.test.ts
@@ -45,4 +45,28 @@ describe("TBL-003: allowed values check", () => {
     const messages = runRules([rule], doc, "test.md");
     expect(messages).toHaveLength(0);
   });
+
+  it("skips files not matching the files pattern", () => {
+    const md = `
+| ID | Status |
+|----|--------|
+| 1  | invalid |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl003({ column: "Status", values: ["done"], files: "**/requirements.md" });
+    const messages = runRules([rule], doc, "docs/overview.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("checks files matching the files pattern", () => {
+    const md = `
+| ID | Status |
+|----|--------|
+| 1  | invalid |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl003({ column: "Status", values: ["done"], files: "**/requirements.md" });
+    const messages = runRules([rule], doc, "docs/requirements.md");
+    expect(messages).toHaveLength(1);
+  });
 });

--- a/packages/core/src/rules/tbl-003.ts
+++ b/packages/core/src/rules/tbl-003.ts
@@ -1,16 +1,24 @@
+import picomatch from "picomatch";
 import type { Rule } from "../rule.js";
 
 export interface Tbl003Options {
   column: string;
   values: string[];
+  files?: string;
 }
 
 export function tbl003(options: Tbl003Options): Rule {
+  const isMatch = options.files ? picomatch(`**/${options.files}`) : null;
+
   return {
     id: "TBL-003",
     description: "Cell values must be from an allowed list",
     severity: "error",
     check: (context) => {
+      if (isMatch && !isMatch(context.filePath)) {
+        return;
+      }
+
       for (const table of context.document.tables) {
         if (!table.headers.includes(options.column)) {
           continue;

--- a/packages/core/src/rules/tbl-004.test.ts
+++ b/packages/core/src/rules/tbl-004.test.ts
@@ -60,4 +60,18 @@ describe("TBL-004", () => {
     const messages = runRules([rule], doc, "test.md");
     expect(messages).toHaveLength(0);
   });
+
+  it("skips files not matching the files pattern", () => {
+    const doc = parseDocument(invalidTable);
+    const rule = tbl004({ column: "ID", pattern: "^[A-Z]+-[A-Z]+-\\d{2}$", files: "**/requirements.md" });
+    const messages = runRules([rule], doc, "docs/overview.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("checks files matching the files pattern", () => {
+    const doc = parseDocument(invalidTable);
+    const rule = tbl004({ column: "ID", pattern: "^[A-Z]+-[A-Z]+-\\d{2}$", files: "**/requirements.md" });
+    const messages = runRules([rule], doc, "docs/requirements.md");
+    expect(messages).toHaveLength(2);
+  });
 });

--- a/packages/core/src/rules/tbl-004.ts
+++ b/packages/core/src/rules/tbl-004.ts
@@ -1,18 +1,25 @@
+import picomatch from "picomatch";
 import type { Rule } from "../rule.js";
 
 export interface Tbl004Options {
   column: string;
   pattern: string;
+  files?: string;
 }
 
 export function tbl004(options: Tbl004Options): Rule {
   const regex = new RegExp(options.pattern);
+  const isMatch = options.files ? picomatch(`**/${options.files}`) : null;
 
   return {
     id: "TBL-004",
     description: "Cell values must match the specified pattern",
     severity: "error",
     check: (context) => {
+      if (isMatch && !isMatch(context.filePath)) {
+        return;
+      }
+
       for (const table of context.document.tables) {
         if (!table.headers.includes(options.column)) {
           continue;


### PR DESCRIPTION
## Summary
- Add optional `files` glob parameter to TBL-001, TBL-002, TBL-003, and TBL-004
- When specified, the rule only applies to files matching the pattern (e.g. `**/requirements.md`)
- When omitted, the rule applies to all files (backwards-compatible)
- Same approach as SEC-001's `files` option (picomatch)

Closes #16

## Test plan
- [x] TBL-001: skips non-matching files, checks matching files, checks all when unset
- [x] TBL-002: skips non-matching files, checks matching files
- [x] TBL-003: skips non-matching files, checks matching files
- [x] TBL-004: skips non-matching files, checks matching files
- [x] All 102 existing tests pass