### PR TITLE
fix(core): skip non-file URI schemes in link extraction

### DIFF
--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -79,4 +79,20 @@ Some paragraph text.
     const doc = parseDocument(md);
     expect(doc.tables[0].line).toBe(3);
   });
+
+  it("collects relative file links but skips URI schemes", () => {
+    const md = `
+[local](./other.md)
+[absolute](https://example.com)
+[email](mailto:user@example.com)
+[phone](tel:+1234567890)
+[data](data:text/plain;base64,abc)
+[anchor](#section)
+[relative](../docs/spec.md)
+`;
+    const doc = parseDocument(md);
+    expect(doc.links).toHaveLength(2);
+    expect(doc.links[0].url).toBe("./other.md");
+    expect(doc.links[1].url).toBe("../docs/spec.md");
+  });
 });

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -82,14 +82,18 @@ export function parseDocument(content: string): ParsedDocument {
   });
 
   // Collect relative links (inline and reference-style)
+  // Skip absolute URLs, anchors, and non-file URI schemes (mailto:, tel:, data:, etc.)
+  const isRelativeFileLink = (url: string) =>
+    !url.startsWith("#") && !/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(url);
+
   visit(tree, "link", (node: Link) => {
-    if (!node.url.startsWith("http") && !node.url.startsWith("#")) {
+    if (isRelativeFileLink(node.url)) {
       links.push({ url: node.url, line: node.position?.start.line ?? 0 });
     }
   });
 
   visit(tree, "definition", (node: Definition) => {
-    if (!node.url.startsWith("http") && !node.url.startsWith("#")) {
+    if (isRelativeFileLink(node.url)) {
       links.push({ url: node.url, line: node.position?.start.line ?? 0 });
     }
   });


### PR DESCRIPTION
## Summary
- Skip `mailto:`, `tel:`, `data:`, and other non-file URI schemes when collecting relative links in the parser
- Uses a generic regex (`/^[a-zA-Z][a-zA-Z\d+.-]*:/`) to match any URI scheme per RFC 3986, instead of hardcoding individual schemes
- Previously only `http`/`https` and `#` anchors were skipped

Closes #17

## Test plan
- [x] Parser test: `mailto:`, `tel:`, `data:` links are excluded; relative links are kept
- [x] All existing REF-001 tests pass