### PR TITLE
feat(core): add exclude option to REF-001

### DIFF
--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -37,7 +37,8 @@ const registry: Record<string, RuleFactory> = {
         idPattern: string;
       },
     ),
-  ref001: () => ref001(),
+  ref001: (options) =>
+    ref001(options as { exclude?: string[] } | undefined),
   ref004: (options) =>
     ref004(
       options as {

--- a/packages/core/src/rules/ref-001.test.ts
+++ b/packages/core/src/rules/ref-001.test.ts
@@ -3,13 +3,15 @@ import { parseDocument, runRules } from "../index.js";
 import type { ParsedDocument } from "../index.js";
 import { ref001 } from "./ref-001.js";
 
-function lint(currentFile: string, filesMap: Record<string, string>) {
+import type { Ref001Options } from "./ref-001.js";
+
+function lint(currentFile: string, filesMap: Record<string, string>, options?: Ref001Options) {
   const documents = new Map<string, ParsedDocument>();
   for (const [path, content] of Object.entries(filesMap)) {
     documents.set(path, parseDocument(content));
   }
 
-  const rule = ref001();
+  const rule = ref001(options);
   const doc = documents.get(currentFile)!;
   return runRules([rule], doc, currentFile, { documents });
 }
@@ -95,5 +97,30 @@ describe("REF-001", () => {
     const doc = parseDocument("[link](./file.md)");
     const messages = runRules([rule], doc, "/project/test.md");
     expect(messages).toEqual([]);
+  });
+
+  it("skips links matching exclude patterns", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md":
+        "[ref repo](../../_references/other-repo/docs/spec.md) and [local](./missing.md)",
+    }, { exclude: ["_references/**"] });
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain("./missing.md");
+  });
+
+  it("supports multiple exclude patterns", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md":
+        "[ref](../../_references/spec.md) and [prisma](../../../prisma/seed/setup.ts)",
+    }, { exclude: ["_references/**", "prisma/**"] });
+    expect(messages).toHaveLength(0);
+  });
+
+  it("checks all links when exclude is not set", () => {
+    const messages = lint("/project/docs/overview.md", {
+      "/project/docs/overview.md":
+        "[ref](../../_references/spec.md)",
+    });
+    expect(messages).toHaveLength(1);
   });
 });

--- a/packages/core/src/rules/ref-001.ts
+++ b/packages/core/src/rules/ref-001.ts
@@ -1,7 +1,14 @@
 import { resolve, dirname } from "node:path";
+import picomatch from "picomatch";
 import type { Rule } from "../rule.js";
 
-export function ref001(): Rule {
+export interface Ref001Options {
+  exclude?: string[];
+}
+
+export function ref001(options?: Ref001Options): Rule {
+  const excludeMatchers = options?.exclude?.map((p) => picomatch(`**/${p}`)) ?? [];
+
   return {
     id: "REF-001",
     description: "All relative Markdown links must point to files that exist",
@@ -17,6 +24,12 @@ export function ref001(): Rule {
         // Strip anchor fragment (e.g. ./file.md#section -> ./file.md)
         const urlWithoutAnchor = link.url.split("#")[0];
         if (!urlWithoutAnchor) {
+          continue;
+        }
+
+        // Strip leading ../ or ./ to match against exclude patterns
+        const stripped = urlWithoutAnchor.replace(/^(\.\.?\/)+/, "");
+        if (excludeMatchers.some((m) => m(stripped))) {
           continue;
         }
 


### PR DESCRIPTION
## Summary
- Add optional `exclude` glob array parameter to REF-001
- Links matching any exclude pattern are skipped (e.g. `_references/**`, `prisma/**`)
- Leading `../` segments are stripped before matching, so `../../_references/spec.md` matches `_references/**`
- When omitted, all links are checked (backwards-compatible)

Closes #18

## Test plan
- [x] Links matching a single exclude pattern are skipped
- [x] Multiple exclude patterns work together
- [x] All links checked when exclude is not set
- [x] All 106 existing tests pass