### PR TITLE
docs: update READMEs with new rule options

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -57,16 +57,16 @@ contextlint --config contextlint.config.json "docs/**/*.md"
 {
   "rules": [
     // TBL-001: テーブルに必須カラムが存在すること
-    { "rule": "tbl001", "options": { "requiredColumns": ["ID", "Status", "Description"] } },
+    { "rule": "tbl001", "options": { "requiredColumns": ["ID", "Status", "Description"], "files": "**/requirements.md" } },
 
     // TBL-002: キーとなるカラムに空のセルがないこと
-    { "rule": "tbl002", "options": { "columns": ["ID", "Status"] } },
+    { "rule": "tbl002", "options": { "columns": ["ID", "Status"], "files": "**/requirements.md" } },
 
     // TBL-003: カラムの値が許可されたセット内にあること
-    { "rule": "tbl003", "options": { "column": "Status", "values": ["draft", "review", "stable"] } },
+    { "rule": "tbl003", "options": { "column": "Status", "values": ["draft", "review", "stable"], "files": "**/requirements.md" } },
 
     // TBL-004: セルの値が正規表現パターンにマッチすること
-    { "rule": "tbl004", "options": { "column": "ID", "pattern": "^[A-Z]+-[A-Z]+-\\d{2}$" } },
+    { "rule": "tbl004", "options": { "column": "ID", "pattern": "^[A-Z]+-[A-Z]+-\\d{2}$", "files": "**/requirements.md" } },
 
     // TBL-006: 指定された全ファイル間でIDがユニーク（一意）であること
     { "rule": "tbl006", "options": { "files": "**/requirements.md", "column": "ID" } },
@@ -78,7 +78,7 @@ contextlint --config contextlint.config.json "docs/**/*.md"
     { "rule": "str001", "options": { "files": ["docs/overview.md", "docs/requirements.md"] } },
 
     // REF-001: 相対パスの Markdown リンクが実在するファイルを指していること
-    { "rule": "ref001" },
+    { "rule": "ref001", "options": { "exclude": ["_references/**"] } },
 
     // REF-002: 定義された ID が参照されていること、また参照されている ID が実在すること
     {
@@ -162,10 +162,10 @@ npm install -D @contextlint/mcp-server
 
 | ID | 説明 | 設定項目 |
 |----|-------------|--------|
-| TBL-001 | テーブルに必須カラムが存在すること | `requiredColumns` |
-| TBL-002 | 主要なカラムに空のセルがないこと | `columns` |
-| TBL-003 | カラムの値が指定のセットに含まれること | `column`, `values` |
-| TBL-004 | セルの値が正規表現にマッチすること | `column`, `pattern` |
+| TBL-001 | テーブルに必須カラムが存在すること | `requiredColumns`, `files`（任意） |
+| TBL-002 | 主要なカラムに空のセルがないこと | `columns`, `files`（任意） |
+| TBL-003 | カラムの値が指定のセットに含まれること | `column`, `values`, `files`（任意） |
+| TBL-004 | セルの値が正規表現にマッチすること | `column`, `pattern`, `files`（任意） |
 | TBL-006 | 指定ファイル間で ID がユニークであること | `files`, `column`, `idPattern` |
 
 ### セクション / 構造に関するルール
@@ -179,7 +179,7 @@ npm install -D @contextlint/mcp-server
 
 | ID | 説明 | 設定項目 |
 |----|-------------|--------|
-| REF-001 | Markdown のリンク先が実在すること | — |
+| REF-001 | Markdown のリンク先が実在すること | `exclude`（任意） |
 | REF-002 | ID の定義と参照の整合性が取れていること | `definitions`, `references`, `idColumn`, `idPattern` |
 | REF-003 | 依存関係における安定性の順序が守られていること | `stabilityColumn`, `stabilityOrder`, `definitions`, `references` |
 | REF-004 | ゾーン間リンクが概要ファイルで宣言されていること | `zonesDir`, `dependencySection` |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # contextlint
 
-[日本語](README.ja.md)
+🌐 [日本語](README.ja.md)
 
 A rule-based linter for structured Markdown documents.
 
@@ -59,16 +59,16 @@ Example `contextlint.config.json`:
 {
   "rules": [
     // TBL-001: Required columns must exist in tables
-    { "rule": "tbl001", "options": { "requiredColumns": ["ID", "Status", "Description"] } },
+    { "rule": "tbl001", "options": { "requiredColumns": ["ID", "Status", "Description"], "files": "**/requirements.md" } },
 
     // TBL-002: Key columns must not have empty cells
-    { "rule": "tbl002", "options": { "columns": ["ID", "Status"] } },
+    { "rule": "tbl002", "options": { "columns": ["ID", "Status"], "files": "**/requirements.md" } },
 
     // TBL-003: Column values must be from an allowed set
-    { "rule": "tbl003", "options": { "column": "Status", "values": ["draft", "review", "stable"] } },
+    { "rule": "tbl003", "options": { "column": "Status", "values": ["draft", "review", "stable"], "files": "**/requirements.md" } },
 
     // TBL-004: Cell values must match a regex pattern
-    { "rule": "tbl004", "options": { "column": "ID", "pattern": "^[A-Z]+-[A-Z]+-\\d{2}$" } },
+    { "rule": "tbl004", "options": { "column": "ID", "pattern": "^[A-Z]+-[A-Z]+-\\d{2}$", "files": "**/requirements.md" } },
 
     // TBL-006: IDs must be unique across all matched files
     { "rule": "tbl006", "options": { "files": "**/requirements.md", "column": "ID" } },
@@ -80,7 +80,7 @@ Example `contextlint.config.json`:
     { "rule": "str001", "options": { "files": ["docs/overview.md", "docs/requirements.md"] } },
 
     // REF-001: Relative Markdown links must point to existing files
-    { "rule": "ref001" },
+    { "rule": "ref001", "options": { "exclude": ["_references/**"] } },
 
     // REF-002: Defined IDs must be referenced; referenced IDs must exist
     {
@@ -164,10 +164,10 @@ Available tools:
 
 | ID | Description | Config |
 |----|-------------|--------|
-| TBL-001 | Required columns must exist in tables | `requiredColumns` |
-| TBL-002 | Key columns must not have empty cells | `columns` |
-| TBL-003 | Column values must be from an allowed set | `column`, `values` |
-| TBL-004 | Cell values must match a regex pattern | `column`, `pattern` |
+| TBL-001 | Required columns must exist in tables | `requiredColumns`, `files` (optional) |
+| TBL-002 | Key columns must not have empty cells | `columns`, `files` (optional) |
+| TBL-003 | Column values must be from an allowed set | `column`, `values`, `files` (optional) |
+| TBL-004 | Cell values must match a regex pattern | `column`, `pattern`, `files` (optional) |
 | TBL-006 | IDs must be unique across all matched files | `files`, `column`, `idPattern` |
 
 ### Section / Structure rules
@@ -181,7 +181,7 @@ Available tools:
 
 | ID | Description | Config |
 |----|-------------|--------|
-| REF-001 | Relative Markdown links must point to existing files | — |
+| REF-001 | Relative Markdown links must point to existing files | `exclude` (optional) |
 | REF-002 | Defined IDs must be referenced; referenced IDs must exist | `definitions`, `references`, `idColumn`, `idPattern` |
 | REF-003 | An item's stability must not exceed the stability of items it depends on | `stabilityColumn`, `stabilityOrder`, `definitions`, `references` |
 | REF-004 | Cross-zone links must be declared in the zone's overview | `zonesDir`, `dependencySection` |


### PR DESCRIPTION
## Summary
- Add `files` option to TBL-001–004 config examples and rule tables (reflects #16/#19)
- Add `exclude` option to REF-001 config example and rule table (reflects #18/#21)
- Add 🌐 icon to Japanese README link

## Test plan
- [x] Verify both READMEs render correctly on GitHub
- [x] Confirm config examples and rule tables match current implementation