### PR TITLE
feat(core): add section option to TBL-001

### DIFF
--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -15,7 +15,7 @@ type RuleFactory = (options?: Record<string, unknown>) => Rule;
 
 const registry: Record<string, RuleFactory> = {
   tbl001: (options) =>
-    tbl001(options as { requiredColumns: string[]; files?: string }),
+    tbl001(options as { requiredColumns: string[]; section?: string; files?: string }),
   tbl002: (options) =>
     tbl002(options as { columns?: string[]; files?: string } | undefined),
   tbl003: (options) =>

--- a/packages/core/src/rules/tbl-001.test.ts
+++ b/packages/core/src/rules/tbl-001.test.ts
@@ -84,4 +84,114 @@ describe("TBL-001: required columns", () => {
     const messages = runRules([rule], doc, "docs/anything.md");
     expect(messages).toHaveLength(1);
   });
+
+  it("only checks tables in the matching section", () => {
+    const md = `
+## What (Requirements)
+
+| ID | Requirement | Stability |
+|----|-------------|-----------|
+| REQ-01 | Something | draft |
+
+## Spec (Specification)
+
+### Stability Model
+
+| Stability | Meaning | Cost of Change |
+|-----------|---------|----------------|
+| draft | Hypothesis | Low |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID", "Stability"], section: "What" });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("reports errors only for tables in the matching section", () => {
+    const md = `
+## What (Requirements)
+
+| Requirement | Stability |
+|-------------|-----------|
+| Something | draft |
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| DNA | Decisions |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID"], section: "What" });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain("ID");
+  });
+
+  it("skips all tables when no section matches", () => {
+    const md = `
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| DNA | Decisions |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID"], section: "What" });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("checks all tables when section option is not set", () => {
+    const md = `
+## What (Requirements)
+
+| ID | Stability |
+|----|-----------|
+| REQ-01 | draft |
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| DNA | Decisions |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID"] });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(1);
+  });
+
+  it("matches section with text between heading and table", () => {
+    const md = `
+## What (Requirements)
+
+This section describes the requirements for the project.
+Here is some additional explanation.
+
+| ID | Requirement | Stability |
+|----|-------------|-----------|
+| REQ-01 | Something | draft |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID", "Stability"], section: "What" });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("combines section and files options", () => {
+    const md = `
+## What (Requirements)
+
+| Requirement | Stability |
+|-------------|-----------|
+| Something | draft |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID"], section: "What", files: "**/requirements.md" });
+    // File matches, section matches -> checks and finds error
+    expect(runRules([rule], doc, "docs/requirements.md")).toHaveLength(1);
+    // File doesn't match -> skips entirely
+    expect(runRules([rule], doc, "docs/overview.md")).toHaveLength(0);
+  });
 });

--- a/packages/core/src/rules/tbl-001.ts
+++ b/packages/core/src/rules/tbl-001.ts
@@ -3,6 +3,7 @@ import type { Rule } from "../rule.js";
 
 export interface Tbl001Options {
   requiredColumns: string[];
+  section?: string;
   files?: string;
 }
 
@@ -19,6 +20,10 @@ export function tbl001(options: Tbl001Options): Rule {
       }
 
       for (const table of context.document.tables) {
+        if (options.section && !table.section?.includes(options.section)) {
+          continue;
+        }
+
         for (const col of options.requiredColumns) {
           if (!table.headers.includes(col)) {
             context.report({


### PR DESCRIPTION
## Summary
- Add optional `section` parameter to TBL-001 that scopes the rule to tables under a specific heading
- Uses partial match (includes) against the nearest heading text, so `section: "What"` matches `## What (Requirements)`
- Text between heading and table does not affect matching
- Combines with existing `files` option for precise targeting
- Backwards compatible: omitting `section` checks all tables as before

## Test plan
- [x] Tables in matching section are checked
- [x] Tables in non-matching sections are skipped
- [x] No section match skips all tables
- [x] All tables checked when `section` is omitted
- [x] Text between heading and table works correctly
- [x] `section` + `files` options combine correctly
- [x] All 112 tests pass
- [x] Build and typecheck pass

Closes #23