### PR TITLE
test(core): add CJK content tests

### DIFF
--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -80,6 +80,53 @@ Some paragraph text.
     expect(doc.tables[0].line).toBe(3);
   });
 
+  it("parses table with Japanese headers and cell values", () => {
+    const md = `
+## 要件定義
+
+| ID | 要件 | 安定度 | 備考 |
+|----|------|--------|------|
+| REQ-AUTH-01 | ユーザー認証 | draft | |
+| REQ-AUTH-02 | パスワードリセット | review | 要確認 |
+`;
+    const doc = parseDocument(md);
+    expect(doc.tables).toHaveLength(1);
+    expect(doc.tables[0].headers).toEqual(["ID", "要件", "安定度", "備考"]);
+    expect(doc.tables[0].rows[0]["要件"]).toBe("ユーザー認証");
+    expect(doc.tables[0].rows[1]["安定度"]).toBe("review");
+    expect(doc.tables[0].section).toBe("要件定義");
+  });
+
+  it("parses table with Korean headers and cell values", () => {
+    const md = `
+## 요구사항
+
+| ID | 요구사항 | 안정도 |
+|----|----------|--------|
+| REQ-01 | 사용자 인증 | draft |
+`;
+    const doc = parseDocument(md);
+    expect(doc.tables).toHaveLength(1);
+    expect(doc.tables[0].headers).toEqual(["ID", "요구사항", "안정도"]);
+    expect(doc.tables[0].rows[0]["요구사항"]).toBe("사용자 인증");
+    expect(doc.tables[0].section).toBe("요구사항");
+  });
+
+  it("parses table with Chinese headers and cell values", () => {
+    const md = `
+## 需求定义
+
+| ID | 需求 | 稳定性 |
+|----|------|--------|
+| REQ-01 | 用户认证 | draft |
+`;
+    const doc = parseDocument(md);
+    expect(doc.tables).toHaveLength(1);
+    expect(doc.tables[0].headers).toEqual(["ID", "需求", "稳定性"]);
+    expect(doc.tables[0].rows[0]["需求"]).toBe("用户认证");
+    expect(doc.tables[0].section).toBe("需求定义");
+  });
+
   it("collects relative file links but skips URI schemes", () => {
     const md = `
 [local](./other.md)

--- a/packages/core/src/rules/sec-001.test.ts
+++ b/packages/core/src/rules/sec-001.test.ts
@@ -80,4 +80,34 @@ describe("SEC-001", () => {
     const messages = runRules([rule], doc, "anything.md");
     expect(messages).toHaveLength(1);
   });
+
+  it("detects Japanese section headings", () => {
+    const doc = parseDocument("# 概要\n\nテキスト\n\n# 要件定義\n\n詳細");
+    const rule = sec001({ sections: ["概要", "要件定義"] });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("reports missing Japanese section headings", () => {
+    const doc = parseDocument("# 概要\n\nテキスト");
+    const rule = sec001({ sections: ["概要", "要件定義", "仕様"] });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(2);
+    expect(messages[0].message).toContain("要件定義");
+    expect(messages[1].message).toContain("仕様");
+  });
+
+  it("detects Korean section headings", () => {
+    const doc = parseDocument("# 개요\n\n텍스트\n\n# 요구사항\n\n상세");
+    const rule = sec001({ sections: ["개요", "요구사항"] });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("detects Chinese section headings", () => {
+    const doc = parseDocument("# 概述\n\n文本\n\n# 需求定义\n\n详情");
+    const rule = sec001({ sections: ["概述", "需求定义"] });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(0);
+  });
 });

--- a/packages/core/src/rules/tbl-001.test.ts
+++ b/packages/core/src/rules/tbl-001.test.ts
@@ -194,4 +194,29 @@ Here is some additional explanation.
     // File doesn't match -> skips entirely
     expect(runRules([rule], doc, "docs/overview.md")).toHaveLength(0);
   });
+
+  it("validates required columns with Japanese column names", () => {
+    const md = `
+| ID | 要件 | 安定度 |
+|----|------|--------|
+| REQ-01 | ユーザー認証 | draft |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID", "安定度"] });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("reports missing Japanese column names", () => {
+    const md = `
+| ID | 要件 |
+|----|------|
+| REQ-01 | ユーザー認証 |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl001({ requiredColumns: ["ID", "安定度"] });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain("安定度");
+  });
 });

--- a/packages/core/src/rules/tbl-003.test.ts
+++ b/packages/core/src/rules/tbl-003.test.ts
@@ -69,4 +69,31 @@ describe("TBL-003: allowed values check", () => {
     const messages = runRules([rule], doc, "docs/requirements.md");
     expect(messages).toHaveLength(1);
   });
+
+  it("validates values in a Japanese column name", () => {
+    const md = `
+| ID | 安定度 |
+|----|--------|
+| REQ-01 | draft |
+| REQ-02 | stable |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl003({ column: "安定度", values: ["draft", "review", "stable"] });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("reports invalid values in a Japanese column name", () => {
+    const md = `
+| ID | 安定度 |
+|----|--------|
+| REQ-01 | 不明 |
+`;
+    const doc = parseDocument(md);
+    const rule = tbl003({ column: "安定度", values: ["draft", "review", "stable"] });
+    const messages = runRules([rule], doc, "test.md");
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain("不明");
+    expect(messages[0].message).toContain("安定度");
+  });
 });


### PR DESCRIPTION
## Summary
- Add Japanese, Korean, and Chinese content tests to verify CJK support
- **Parser**: table headers, cell values, and section detection with CJK characters (3 tests)
- **TBL-001**: `requiredColumns` with Japanese column names like `"安定度"` (2 tests)
- **TBL-003**: value validation on Japanese column names (2 tests)
- **SEC-001**: required section detection with Japanese, Korean, and Chinese headings (4 tests)

## Test plan
- [x] All 123 tests pass (112 existing + 11 new CJK tests)

Closes #24