### PR TITLE
feat(vscode): add @contextlint/vscode extension (MVP)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch @contextlint/vscode extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/packages/vscode/dist/**/*.js"
+      ]
+    }
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,17 @@
         "zod": "^4.3.6",
       },
     },
+    "packages/vscode": {
+      "name": "@contextlint/vscode",
+      "version": "0.0.0",
+      "dependencies": {
+        "@contextlint/lsp-server": "workspace:*",
+        "vscode-languageclient": "^9.0.1",
+      },
+      "devDependencies": {
+        "@types/vscode": "^1.82.0",
+      },
+    },
   },
   "packages": {
     "@contextlint/cli": ["@contextlint/cli@workspace:packages/cli"],
@@ -77,6 +88,8 @@
     "@contextlint/lsp-server": ["@contextlint/lsp-server@workspace:packages/lsp-server"],
 
     "@contextlint/mcp-server": ["@contextlint/mcp-server@workspace:packages/mcp-server"],
+
+    "@contextlint/vscode": ["@contextlint/vscode@workspace:packages/vscode"],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -167,6 +180,8 @@
     "@types/picomatch": ["@types/picomatch@4.0.2", "", {}, "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/vscode": ["@types/vscode@1.116.0", "", {}, "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/type-utils": "8.56.1", "@typescript-eslint/utils": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A=="],
 
@@ -688,6 +703,8 @@
 
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
+    "vscode-languageclient": ["vscode-languageclient@9.0.1", "", { "dependencies": { "minimatch": "^5.1.0", "semver": "^7.3.7", "vscode-languageserver-protocol": "3.17.5" } }, "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA=="],
+
     "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
 
     "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
@@ -730,8 +747,14 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
+    "vscode-languageclient/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "vscode-languageclient/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "vscode-languageclient/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/packages/lsp-server/package.json
+++ b/packages/lsp-server/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "bin": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@contextlint/vscode",
+  "version": "0.0.0",
+  "displayName": "contextlint",
+  "description": "In-editor diagnostics for structured Markdown documents",
+  "private": true,
+  "publisher": "contextlint",
+  "engines": {
+    "vscode": "^1.82.0"
+  },
+  "main": "./dist/extension.js",
+  "activationEvents": [
+    "onLanguage:markdown"
+  ],
+  "contributes": {
+    "configuration": {
+      "title": "contextlint",
+      "properties": {
+        "contextlint.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable contextlint diagnostics."
+        },
+        "contextlint.trace.server": {
+          "type": "string",
+          "enum": ["off", "messages", "verbose"],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the contextlint language server."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@contextlint/lsp-server": "workspace:*",
+    "vscode-languageclient": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.82.0"
+  },
+  "license": "MIT"
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,0 +1,40 @@
+import { workspace } from "vscode";
+import type { ExtensionContext } from "vscode";
+import { LanguageClient, TransportKind } from "vscode-languageclient/node";
+import type {
+  LanguageClientOptions,
+  ServerOptions,
+} from "vscode-languageclient/node";
+
+let client: LanguageClient | undefined;
+
+export function activate(_context: ExtensionContext): void {
+  const enabled = workspace
+    .getConfiguration("contextlint")
+    .get<boolean>("enable", true);
+  if (!enabled) return;
+
+  const serverModule = require.resolve("@contextlint/lsp-server");
+
+  const serverOptions: ServerOptions = {
+    run: { module: serverModule, transport: TransportKind.stdio },
+    debug: { module: serverModule, transport: TransportKind.stdio },
+  };
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [{ scheme: "file", language: "markdown" }],
+  };
+
+  client = new LanguageClient(
+    "contextlint",
+    "contextlint",
+    serverOptions,
+    clientOptions,
+  );
+
+  void client.start();
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  return client?.stop();
+}

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `@contextlint/vscode`, a thin VS Code extension that spawns `@contextlint/lsp-server` and surfaces its diagnostics and hover content to the editor.
- One extension covers VS Code, Cursor, Windsurf, VSCodium — every downstream VS Code fork / Open VSX consumer.
- Uses `vscode-languageclient/node` with stdio transport. Server module resolved via `require.resolve("@contextlint/lsp-server")` — no hard-coded path.

Part of #90 (Epic: Language Server + VS Code extension).
Closes #93.

## Configuration

| Setting | Type | Default | Description |
|---------|------|---------|-------------|
| `contextlint.enable` | boolean | `true` | Enable contextlint diagnostics. |
| `contextlint.trace.server` | `"off"` \| `"messages"` \| `"verbose"` | `"off"` | LSP trace verbosity. |

## Package layout

```
packages/vscode/
├── package.json          # extension manifest
├── tsconfig.json         # CJS (module / moduleResolution: node16)
└── src/
    └── extension.ts      # activate / deactivate
```

## Test plan

- [x] `bun run --filter '*' build` — all 5 packages pass
- [x] `bun run --filter '*' typecheck` — pass
- [x] `bun test` — 746 tests passing (no new tests added; extension is tested manually)
- [x] `npx eslint .` — 0 errors
- [x] Manual verification via the Extension Development Host:
  1. `bun run --filter '@contextlint/vscode' build`
  2. Open this repo in VS Code and press F5 (uses `.vscode/launch.json`)
  3. In the Extension Development Host window, open a workspace that has a `contextlint.config.json` with at least one rule (e.g. `tbl001` with `requiredColumns`)
  4. Open a Markdown file that violates the rule — confirm a squiggle appears
  5. Hover the squiggle — confirm the rule ID + message panel renders
  6. Toggle `contextlint.enable` to `false` and reload the window — diagnostics disappear

## Notes

- `engines.vscode` pinned to `^1.82.0` (the minimum that `vscode-languageclient@9` supports) for maximal downstream compatibility.
- Marked `"private": true` — not published to npm or the VS Code Marketplace. Publishing is out of scope for this phase; a separate phase will handle VSIX packaging, icon / banner assets, and Marketplace + Open VSX release.
- tsconfig overrides `module` / `moduleResolution` to `node16` (CJS) and disables `verbatimModuleSyntax`, since `vscode` and `vscode-languageclient` are CommonJS and `require.resolve` is needed to locate the server entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nozomi-koborinai/codesmith/contextlint/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->