### PR TITLE
fix(vscode): rename package to contextlint-vscode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,7 +69,7 @@
       },
     },
     "packages/vscode": {
-      "name": "@contextlint/vscode",
+      "name": "contextlint-vscode",
       "version": "0.0.0",
       "dependencies": {
         "@contextlint/lsp-server": "workspace:*",
@@ -88,8 +88,6 @@
     "@contextlint/lsp-server": ["@contextlint/lsp-server@workspace:packages/lsp-server"],
 
     "@contextlint/mcp-server": ["@contextlint/mcp-server@workspace:packages/mcp-server"],
-
-    "@contextlint/vscode": ["@contextlint/vscode@workspace:packages/vscode"],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -252,6 +250,8 @@
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "contextlint-vscode": ["contextlint-vscode@workspace:packages/vscode"],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@contextlint/vscode",
+  "name": "contextlint-vscode",
   "version": "0.0.0",
   "displayName": "contextlint",
   "description": "In-editor diagnostics for structured Markdown documents",


### PR DESCRIPTION
## Summary

- Renames `packages/vscode`'s npm name from `@contextlint/vscode` to `contextlint-vscode`.
- VS Code extension IDs are `<publisher>.<name>`, and the `name` field must match `^[a-z0-9][a-z0-9-]*$` ([manifest reference](https://code.visualstudio.com/api/references/extension-manifest)). The scoped form `@contextlint/vscode` is invalid, which caused `Activating extension 'contextlint.@contextlint/vsco...' failed` in the Extension Development Host.
- Other `@contextlint/*` packages (core, cli, mcp-server, lsp-server) are unaffected — they keep their scoped names.

This should have been part of #94. The naming issue was caught during
EDH verification, but the fix was not committed before the merge.

Part of #90. Follows up #94.

## Test plan

- [x] `bun run --filter '*' build` — all 5 packages build
- [x] `bun run --filter '*' typecheck` — pass
- [x] `bun test` — 746 tests pass
- [x] `npx eslint .` — 0 errors
- [x] Manual verification in Extension Development Host: extension activates, diagnostics + hover work end-to-end (already verified locally with this rename applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)