### PR TITLE
fix(core): report table-based rule violations at the actual row line

### DIFF
--- a/packages/core/src/context-compiler.ts
+++ b/packages/core/src/context-compiler.ts
@@ -185,7 +185,7 @@ export function extractDocProfile(
       let idPattern: string | null = null;
       for (const col of table.headers) {
         const colValues = table.rows
-          .map((row) => row[col] ?? "")
+          .map((row) => row.cells[col] ?? "")
           .filter((v) => v.length > 0);
         const pattern = detectIdPattern(colValues);
         if (pattern) {

--- a/packages/core/src/context-graph.ts
+++ b/packages/core/src/context-graph.ts
@@ -201,7 +201,7 @@ export function getContextSlice(
       let found = false;
       for (const table of doc.tables) {
         for (const row of table.rows) {
-          for (const value of Object.values(row)) {
+          for (const value of Object.values(row.cells)) {
             if (value === query) {
               found = true;
               break;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export type {
   ParsedImage,
   ParsedLink,
   ParsedTable,
+  ParsedTableRow,
   ParsedDocument,
 } from "./parser.js";
 

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -13,8 +13,8 @@ describe("parseDocument", () => {
     expect(doc.tables).toHaveLength(1);
     expect(doc.tables[0].headers).toEqual(["Name", "Age"]);
     expect(doc.tables[0].rows).toEqual([
-      { Name: "Alice", Age: "30" },
-      { Name: "Bob", Age: "25" },
+      { line: 4, cells: { Name: "Alice", Age: "30" } },
+      { line: 5, cells: { Name: "Bob", Age: "25" } },
     ]);
     expect(doc.tables[0].section).toBeNull();
   });
@@ -82,9 +82,12 @@ Some paragraph text.
 | H1 | H2 |
 |----|----|
 | v1 | v2 |
+| v3 | v4 |
 `;
     const doc = parseDocument(md);
     expect(doc.tables[0].line).toBe(3);
+    expect(doc.tables[0].rows[0].line).toBe(5);
+    expect(doc.tables[0].rows[1].line).toBe(6);
   });
 
   it("parses table with Japanese headers and cell values", () => {
@@ -99,8 +102,8 @@ Some paragraph text.
     const doc = parseDocument(md);
     expect(doc.tables).toHaveLength(1);
     expect(doc.tables[0].headers).toEqual(["ID", "要件", "安定度", "備考"]);
-    expect(doc.tables[0].rows[0]["要件"]).toBe("ユーザー認証");
-    expect(doc.tables[0].rows[1]["安定度"]).toBe("review");
+    expect(doc.tables[0].rows[0].cells["要件"]).toBe("ユーザー認証");
+    expect(doc.tables[0].rows[1].cells["安定度"]).toBe("review");
     expect(doc.tables[0].section).toBe("要件定義");
   });
 
@@ -115,7 +118,7 @@ Some paragraph text.
     const doc = parseDocument(md);
     expect(doc.tables).toHaveLength(1);
     expect(doc.tables[0].headers).toEqual(["ID", "요구사항", "안정도"]);
-    expect(doc.tables[0].rows[0]["요구사항"]).toBe("사용자 인증");
+    expect(doc.tables[0].rows[0].cells["요구사항"]).toBe("사용자 인증");
     expect(doc.tables[0].section).toBe("요구사항");
   });
 
@@ -130,7 +133,7 @@ Some paragraph text.
     const doc = parseDocument(md);
     expect(doc.tables).toHaveLength(1);
     expect(doc.tables[0].headers).toEqual(["ID", "需求", "稳定性"]);
-    expect(doc.tables[0].rows[0]["需求"]).toBe("用户认证");
+    expect(doc.tables[0].rows[0].cells["需求"]).toBe("用户认证");
     expect(doc.tables[0].section).toBe("需求定义");
   });
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -14,11 +14,16 @@ import type {
 } from "mdast";
 import type { Node } from "unist";
 
+export interface ParsedTableRow {
+  line: number;
+  cells: Record<string, string>;
+}
+
 export interface ParsedTable {
   line: number;
   section: string | null;
   headers: string[];
-  rows: Record<string, string>[];
+  rows: ParsedTableRow[];
 }
 
 export interface ParsedLink {
@@ -91,13 +96,16 @@ export function parseDocument(content: string): ParsedDocument {
     if (!headerRow) return;
     const headers = extractCellText(headerRow);
 
-    const rows = dataRows.map((row) => {
+    const rows: ParsedTableRow[] = dataRows.map((row) => {
       const cells = extractCellText(row);
       const record: Record<string, string> = {};
       headers.forEach((header, i) => {
         record[header] = cells[i] ?? "";
       });
-      return record;
+      return {
+        line: row.position?.start.line ?? 0,
+        cells: record,
+      };
     });
 
     // Find the nearest heading above this table

--- a/packages/core/src/rules/ctx-002.ts
+++ b/packages/core/src/rules/ctx-002.ts
@@ -77,8 +77,8 @@ function extractGlossary(
     }
 
     for (const row of table.rows) {
-      const canonical = row[options.termColumn];
-      const aliasCell = row[aliasColumn];
+      const canonical = row.cells[options.termColumn];
+      const aliasCell = row.cells[aliasColumn];
       if (!canonical || !aliasCell) {
         continue;
       }

--- a/packages/core/src/rules/grp-001.ts
+++ b/packages/core/src/rules/grp-001.ts
@@ -68,14 +68,14 @@ export function grp001(options: Grp001Options): Rule {
               continue;
             }
             for (const row of table.rows) {
-              const value = row[currentColumn];
+              const value = row.cells[currentColumn];
               if (!value) {
                 continue;
               }
               if (idRegex && !idRegex.test(value)) {
                 continue;
               }
-              currentIds.set(value, { filePath, line: table.line });
+              currentIds.set(value, { filePath, line: row.line });
             }
           }
         }
@@ -91,7 +91,7 @@ export function grp001(options: Grp001Options): Rule {
               continue;
             }
             for (const row of table.rows) {
-              const value = row[nextColumn];
+              const value = row.cells[nextColumn];
               if (!value) {
                 continue;
               }

--- a/packages/core/src/rules/ref-002.ts
+++ b/packages/core/src/rules/ref-002.ts
@@ -43,9 +43,9 @@ export function ref002(options: Ref002Options): Rule {
             continue;
           }
           for (const row of table.rows) {
-            const value = row[options.idColumn];
+            const value = row.cells[options.idColumn];
             if (value && idRegex.test(value)) {
-              defined.set(value, { filePath, line: table.line });
+              defined.set(value, { filePath, line: row.line });
             }
           }
         }
@@ -61,7 +61,7 @@ export function ref002(options: Ref002Options): Rule {
         // From table columns
         for (const table of doc.tables) {
           for (const row of table.rows) {
-            for (const value of Object.values(row)) {
+            for (const value of Object.values(row.cells)) {
               if (value && idRegex.test(value)) {
                 referenced.add(value);
               }

--- a/packages/core/src/rules/ref-003.ts
+++ b/packages/core/src/rules/ref-003.ts
@@ -61,8 +61,8 @@ export function ref003(options: Ref003Options): Rule {
             continue;
           }
           for (const row of table.rows) {
-            const id = row[idColumn];
-            const stability = row[options.stabilityColumn];
+            const id = row.cells[idColumn];
+            const stability = row.cells[options.stabilityColumn];
             if (!id || !stability) {
               continue;
             }
@@ -84,7 +84,7 @@ export function ref003(options: Ref003Options): Rule {
             continue;
           }
           for (const row of table.rows) {
-            const refStability = row[options.stabilityColumn];
+            const refStability = row.cells[options.stabilityColumn];
             if (!refStability || !stabilityRank.has(refStability)) {
               continue;
             }
@@ -92,7 +92,7 @@ export function ref003(options: Ref003Options): Rule {
             if (refRank === undefined) continue;
 
             // Find referenced IDs in other cells of this row
-            for (const [col, value] of Object.entries(row)) {
+            for (const [col, value] of Object.entries(row.cells)) {
               if (col === options.stabilityColumn || !value) {
                 continue;
               }
@@ -107,7 +107,7 @@ export function ref003(options: Ref003Options): Rule {
                 context.report({
                   severity: "warning",
                   message: `Item "${value}" has stability "${def.stability}" in ${def.filePath}, but is referenced from a row with stability "${refStability}" in ${filePath}`,
-                  line: table.line,
+                  line: row.line,
                 });
               }
             }

--- a/packages/core/src/rules/ref-004.ts
+++ b/packages/core/src/rules/ref-004.ts
@@ -83,7 +83,7 @@ export function ref004(options: Ref004Options): Rule {
               continue;
             }
             for (const row of table.rows) {
-              for (const value of Object.values(row)) {
+              for (const value of Object.values(row.cells)) {
                 if (value) {
                   declaredDeps.add(value.trim());
                 }

--- a/packages/core/src/rules/tbl-002.ts
+++ b/packages/core/src/rules/tbl-002.ts
@@ -28,11 +28,12 @@ export function tbl002(options?: Tbl002Options): Rule {
 
         for (const row of table.rows) {
           for (const col of targetColumns) {
-            if (!row[col] || row[col].trim() === "") {
+            const value = row.cells[col];
+            if (!value || value.trim() === "") {
               context.report({
                 severity: "warning",
                 message: `Empty cell in column "${col}"`,
-                line: table.line,
+                line: row.line,
               });
             }
           }

--- a/packages/core/src/rules/tbl-003.ts
+++ b/packages/core/src/rules/tbl-003.ts
@@ -28,12 +28,12 @@ export function tbl003(options: Tbl003Options): Rule {
         }
 
         for (const row of table.rows) {
-          const value = row[options.column];
+          const value = row.cells[options.column];
           if (value && !options.values.includes(value)) {
             context.report({
               severity: "error",
               message: `Invalid value "${value}" in column "${options.column}". Allowed: ${options.values.join(", ")}`,
-              line: table.line,
+              line: row.line,
             });
           }
         }

--- a/packages/core/src/rules/tbl-004.ts
+++ b/packages/core/src/rules/tbl-004.ts
@@ -30,12 +30,12 @@ export function tbl004(options: Tbl004Options): Rule {
         }
 
         for (const row of table.rows) {
-          const value = row[options.column];
+          const value = row.cells[options.column];
           if (value && !regex.test(value)) {
             context.report({
               severity: "error",
               message: `Value "${value}" in column "${options.column}" does not match pattern "${options.pattern}"`,
-              line: table.line,
+              line: row.line,
             });
           }
         }

--- a/packages/core/src/rules/tbl-005.ts
+++ b/packages/core/src/rules/tbl-005.ts
@@ -85,7 +85,7 @@ export function tbl005(options: Tbl005Options): Rule {
         }
 
         for (const row of table.rows) {
-          const conditionValue = row[options.when.column];
+          const conditionValue = row.cells[options.when.column];
           if (!conditionValue) {
             continue;
           }
@@ -94,14 +94,14 @@ export function tbl005(options: Tbl005Options): Rule {
             continue;
           }
 
-          const constraintValue = row[options.then.column];
+          const constraintValue = row.cells[options.then.column];
           if (violatesConstraint(constraintValue, options.then)) {
             const conditionDesc = describeCondition(options.when);
             const constraintDesc = describeConstraint(options.then);
             context.report({
               severity: "error",
               message: `Row where ${conditionDesc}: column "${options.then.column}" ${constraintDesc}`,
-              line: table.line,
+              line: row.line,
             });
           }
         }

--- a/packages/core/src/rules/tbl-006.ts
+++ b/packages/core/src/rules/tbl-006.ts
@@ -39,7 +39,7 @@ export function tbl006(options: Tbl006Options): Rule {
           }
 
           for (const row of table.rows) {
-            const value = row[options.column];
+            const value = row.cells[options.column];
             if (!value) {
               continue;
             }
@@ -52,10 +52,10 @@ export function tbl006(options: Tbl006Options): Rule {
               context.report({
                 severity: "error",
                 message: `ID "${value}" is already defined in ${existing.filePath}:${String(existing.line)}`,
-                line: table.line,
+                line: row.line,
               });
             } else {
-              seen.set(value, { filePath, line: table.line });
+              seen.set(value, { filePath, line: row.line });
             }
           }
         }


### PR DESCRIPTION
## Summary

Fixes a long-standing bug where 8 rules detecting row-level violations
reported them at the table's header line (`table.line`) instead of the
actual offending row. Root cause: `ParsedTable.rows` was typed
`Record<string, string>[]`, discarding each row's line information.

Part of #90 (Epic).
Closes #97.
Blocks #96 (Phase 3b: Code Action).

## What changes

- `ParsedTable.rows: ParsedTableRow[]` where
  ```ts
  interface ParsedTableRow {
    line: number;
    cells: Record<string, string>;
  }
  ```
- `parseDocument` records each data row's line from the mdast node
  position.
- 8 rules now report at `row.line` and access values via
  `row.cells[col]`:

| Rule | What it detects |
|------|-----------------|
| TBL-002 | empty cell |
| TBL-003 | allowed values |
| TBL-004 | regex pattern |
| TBL-005 | cross-column constraints |
| TBL-006 | unique IDs |
| REF-002 | ID definitions referenced from other files |
| REF-003 | stability dependency |
| GRP-001 | traceability chain |

TBL-001 (required columns) stays at `table.line` — it's genuinely a
table-level concern.

- `ctx-002`, `ref-004`, `context-compiler`, `context-graph`: switch row
  access from `row[col]` to `row.cells[col]`.
- `ParsedTableRow` exported from the public API.
- Parser tests updated for the new row shape + row-line tracking.

## User impact

- **Positive**: editor squiggles (VS Code extension), CLI / MCP / JSON
  output, and hover info now point at the actual violation row instead
  of the table header.
- **Negative**: none for normal usage. Config schema, detection logic,
  rule set — all unchanged. Only affects external scripts that parse
  lint output by line number (functionally none).

## Test plan

- [x] `bun run --filter '*' build` — all 5 packages build
- [x] `bun run --filter '*' typecheck` — pass
- [x] `bun test` — 746/746 passing
- [x] `npx eslint .` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)