### PR TITLE
feat(lsp): add Code Actions for CHK-001 and TBL-002

### DIFF
--- a/packages/lsp-server/src/code-actions.test.ts
+++ b/packages/lsp-server/src/code-actions.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "bun:test";
+import {
+  CodeActionKind,
+  DiagnosticSeverity,
+} from "vscode-languageserver/node.js";
+import type {
+  CodeActionParams,
+  Diagnostic,
+  TextEdit,
+} from "vscode-languageserver/node.js";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { provideCodeActions } from "./code-actions.js";
+
+const URI = "file:///tmp/test.md";
+
+function doc(content: string): TextDocument {
+  return TextDocument.create(URI, "markdown", 1, content);
+}
+
+function diag(line: number, code: string, message = "violation"): Diagnostic {
+  return {
+    severity: DiagnosticSeverity.Warning,
+    range: {
+      start: { line, character: 0 },
+      end: { line, character: 100 },
+    },
+    message,
+    source: "contextlint",
+    code,
+  };
+}
+
+function params(diagnostics: Diagnostic[]): CodeActionParams {
+  return {
+    textDocument: { uri: URI },
+    range: {
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: 0 },
+    },
+    context: { diagnostics },
+  };
+}
+
+function editsFor(action: { edit?: { changes?: Record<string, TextEdit[]> } }): TextEdit[] {
+  const edits = action.edit?.changes?.[URI];
+  if (!edits) throw new Error("expected workspace edit for URI");
+  return edits;
+}
+
+describe("provideCodeActions", () => {
+  it("returns no actions when there are no diagnostics", () => {
+    expect(provideCodeActions(params([]), doc(""))).toEqual([]);
+  });
+
+  it("ignores diagnostics from unsupported rules", () => {
+    const d = doc("# Heading\n");
+    const actions = provideCodeActions(params([diag(0, "TBL-001")]), d);
+    expect(actions).toEqual([]);
+  });
+});
+
+describe("CHK-001 fix", () => {
+  it("produces an edit that flips `[ ]` to `[x]`", () => {
+    const d = doc("- [ ] item\n");
+    const actions = provideCodeActions(params([diag(0, "CHK-001")]), d);
+    expect(actions).toHaveLength(1);
+    const action = actions[0];
+    if (!action) throw new Error("expected one action");
+    expect(action.kind).toBe(CodeActionKind.QuickFix);
+    expect(action.title).toContain("done");
+    const edits = editsFor(action);
+    expect(edits).toEqual([
+      {
+        range: {
+          start: { line: 0, character: 3 },
+          end: { line: 0, character: 4 },
+        },
+        newText: "x",
+      },
+    ]);
+  });
+
+  it("handles indented bullets", () => {
+    const d = doc("  * [ ] indented\n");
+    const actions = provideCodeActions(params([diag(0, "CHK-001")]), d);
+    expect(actions).toHaveLength(1);
+    const action = actions[0];
+    if (!action) throw new Error("expected one action");
+    const edits = editsFor(action);
+    expect(edits[0]?.range.start.character).toBe(5); // after "  * ["
+    expect(edits[0]?.newText).toBe("x");
+  });
+
+  it("returns no action when the line is already checked", () => {
+    const d = doc("- [x] done\n");
+    const actions = provideCodeActions(params([diag(0, "CHK-001")]), d);
+    expect(actions).toEqual([]);
+  });
+
+  it("returns no action when the line is not a checklist item", () => {
+    const d = doc("# Heading\n");
+    const actions = provideCodeActions(params([diag(0, "CHK-001")]), d);
+    expect(actions).toEqual([]);
+  });
+});
+
+describe("TBL-002 fix", () => {
+  it("inserts TODO into a single empty cell", () => {
+    // Line 0: "| ID | Name |"
+    // Line 1: "|----|------|"
+    // Line 2: "| 1  |      |"  ← empty cell between the last two pipes
+    const d = doc("| ID | Name |\n|----|------|\n| 1  |      |\n");
+    const actions = provideCodeActions(params([diag(2, "TBL-002")]), d);
+    expect(actions).toHaveLength(1);
+    const action = actions[0];
+    if (!action) throw new Error("expected one action");
+    expect(action.kind).toBe(CodeActionKind.QuickFix);
+    const edits = editsFor(action);
+    expect(edits).toHaveLength(1);
+    expect(edits[0]?.newText).toBe(" TODO ");
+  });
+
+  it("inserts TODO into multiple empty cells on the same row", () => {
+    // "|   |   |" — two empty cells
+    const d = doc("| A | B |\n|---|---|\n|   |   |\n");
+    const actions = provideCodeActions(params([diag(2, "TBL-002")]), d);
+    expect(actions).toHaveLength(1);
+    const action = actions[0];
+    if (!action) throw new Error("expected one action");
+    const edits = editsFor(action);
+    expect(edits).toHaveLength(2);
+    for (const e of edits) {
+      expect(e.newText).toBe(" TODO ");
+    }
+  });
+
+  it("returns no action when the row has no empty cells", () => {
+    const d = doc("| A | B |\n|---|---|\n| 1 | 2 |\n");
+    const actions = provideCodeActions(params([diag(2, "TBL-002")]), d);
+    expect(actions).toEqual([]);
+  });
+
+  it("returns no action on a line without pipes", () => {
+    const d = doc("just text\n");
+    const actions = provideCodeActions(params([diag(0, "TBL-002")]), d);
+    expect(actions).toEqual([]);
+  });
+});
+
+describe("mixed diagnostics", () => {
+  it("produces actions for CHK-001 and TBL-002 on different lines", () => {
+    // line 0: checklist; lines 2-4: table with an empty cell on line 4
+    const d = doc(
+      "- [ ] todo\n\n| A | B |\n|---|---|\n|   | 2 |\n",
+    );
+    const actions = provideCodeActions(
+      params([diag(0, "CHK-001"), diag(4, "TBL-002")]),
+      d,
+    );
+    expect(actions).toHaveLength(2);
+    expect(actions[0]?.title).toContain("done");
+    expect(actions[1]?.title).toContain("TODO");
+  });
+});

--- a/packages/lsp-server/src/code-actions.ts
+++ b/packages/lsp-server/src/code-actions.ts
@@ -1,0 +1,123 @@
+import { CodeActionKind } from "vscode-languageserver/node.js";
+import type {
+  CodeAction,
+  CodeActionParams,
+  Diagnostic,
+  TextEdit,
+} from "vscode-languageserver/node.js";
+import type { TextDocument } from "vscode-languageserver-textdocument";
+
+const TBL_002_PLACEHOLDER = "TODO";
+
+/**
+ * Build CodeActions for the diagnostics in this request. One translator
+ * per supported rule ID; unsupported rules produce no actions.
+ */
+export function provideCodeActions(
+  params: CodeActionParams,
+  document: TextDocument,
+): CodeAction[] {
+  const actions: CodeAction[] = [];
+  for (const diagnostic of params.context.diagnostics) {
+    const ruleId = diagnosticCode(diagnostic);
+    if (ruleId === "CHK-001") {
+      const action = fixChk001(diagnostic, document);
+      if (action) actions.push(action);
+    } else if (ruleId === "TBL-002") {
+      const action = fixTbl002(diagnostic, document);
+      if (action) actions.push(action);
+    }
+  }
+  return actions;
+}
+
+function diagnosticCode(d: Diagnostic): string {
+  if (typeof d.code === "string") return d.code;
+  if (typeof d.code === "number") return String(d.code);
+  return "";
+}
+
+function getLineText(document: TextDocument, line: number): string {
+  const text = document.getText({
+    start: { line, character: 0 },
+    end: { line: line + 1, character: 0 },
+  });
+  return text.replace(/\r?\n$/, "");
+}
+
+function fixChk001(
+  diagnostic: Diagnostic,
+  document: TextDocument,
+): CodeAction | null {
+  const line = diagnostic.range.start.line;
+  const lineText = getLineText(document, line);
+  const match = /^(\s*[-*+]\s+)\[ \]/.exec(lineText);
+  if (!match) return null;
+  const prefix = match[1];
+  if (prefix === undefined) return null;
+  const spaceInsideBracket = prefix.length + 1;
+
+  const edit: TextEdit = {
+    range: {
+      start: { line, character: spaceInsideBracket },
+      end: { line, character: spaceInsideBracket + 1 },
+    },
+    newText: "x",
+  };
+  return {
+    title: "Mark checklist item as done",
+    kind: CodeActionKind.QuickFix,
+    diagnostics: [diagnostic],
+    edit: {
+      changes: {
+        [document.uri]: [edit],
+      },
+    },
+  };
+}
+
+function fixTbl002(
+  diagnostic: Diagnostic,
+  document: TextDocument,
+): CodeAction | null {
+  const line = diagnostic.range.start.line;
+  const lineText = getLineText(document, line);
+
+  const pipePositions: number[] = [];
+  for (let i = 0; i < lineText.length; i++) {
+    if (lineText[i] === "|") pipePositions.push(i);
+  }
+  if (pipePositions.length < 2) return null;
+
+  const edits: TextEdit[] = [];
+  for (let i = 0; i < pipePositions.length - 1; i++) {
+    const leftPipe = pipePositions[i];
+    const rightPipe = pipePositions[i + 1];
+    if (leftPipe === undefined || rightPipe === undefined) continue;
+    const cellStart = leftPipe + 1;
+    const cellEnd = rightPipe;
+    const cell = lineText.slice(cellStart, cellEnd);
+    if (cell.trim() === "") {
+      edits.push({
+        range: {
+          start: { line, character: cellStart },
+          end: { line, character: cellEnd },
+        },
+        newText: ` ${TBL_002_PLACEHOLDER} `,
+      });
+    }
+  }
+
+  if (edits.length === 0) return null;
+
+  return {
+    title: `Fill empty cells with "${TBL_002_PLACEHOLDER}"`,
+    kind: CodeActionKind.QuickFix,
+    diagnostics: [diagnostic],
+    edit: {
+      changes: {
+        [document.uri]: edits,
+      },
+    },
+  };
+}

--- a/packages/lsp-server/src/server.ts
+++ b/packages/lsp-server/src/server.ts
@@ -11,6 +11,7 @@ import type {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import type { LoadedConfig } from "./config-loader.js";
 import { tryLoadConfig } from "./config-loader.js";
+import { provideCodeActions } from "./code-actions.js";
 import { toDiagnostics } from "./diagnostics.js";
 import { hoverForDiagnostics } from "./hover.js";
 import { lintBuffer } from "./linter.js";
@@ -41,6 +42,7 @@ export function start(): void {
       capabilities: {
         textDocumentSync: TextDocumentSyncKind.Incremental,
         hoverProvider: true,
+        codeActionProvider: true,
       },
       serverInfo: { name: "contextlint-lsp" },
     };
@@ -66,6 +68,12 @@ export function start(): void {
   connection.onHover((params) => {
     const diagnostics = latestDiagnostics.get(params.textDocument.uri) ?? [];
     return hoverForDiagnostics(params, diagnostics);
+  });
+
+  connection.onCodeAction((params) => {
+    const document = documents.get(params.textDocument.uri);
+    if (!document) return [];
+    return provideCodeActions(params, document);
   });
 
   documents.listen(connection);


### PR DESCRIPTION
## Summary

- Adds Quick Fix support to `@contextlint/lsp-server`. For each diagnostic at the cursor, the server can now propose a mechanical fix that the editor applies via `WorkspaceEdit`.
- Wave 1 rules:
  - **CHK-001**: `- [ ]` → `- [x]` (flips the single space inside the checkbox — minimal edit so surrounding text is preserved).
  - **TBL-002**: empty cells on the violation's row get a `TODO` placeholder inserted. Handles multiple empty cells on one row.
- Extension (`contextlint-vscode`) requires no changes — Code Actions are relayed automatically by `vscode-languageclient`.

Part of #90 (Epic).
Closes #96.

## What changes

- `packages/lsp-server/src/code-actions.ts` — new module. `provideCodeActions(params, document)` dispatches per rule ID.
- `packages/lsp-server/src/server.ts` — `codeActionProvider: true` capability + `connection.onCodeAction` handler.
- `packages/lsp-server/src/code-actions.test.ts` — 11 unit tests.

## Test plan

- [x] `bun run --filter '*' build` — all 5 packages
- [x] `bun run --filter '*' typecheck` — pass
- [x] `bun test` — 757/757 (11 new for code-actions)
- [x] `npx eslint .` — 0 errors
- [x] Manual verification in Extension Development Host:
  1. `bun run --filter '@contextlint/lsp-server' build`
  2. Open this repo in VS Code, press F5
  3. In the EDH, open a workspace with a `contextlint.config.json` (e.g. `~/StudioProjects/contextlint-edh-test`)
  4. **CHK-001**: add `- [ ] todo` under a chk001-targeted section → cursor on the line → lightbulb → "Mark checklist item as done" → item becomes `- [x]`
  5. **TBL-002**: empty cell in a tbl002-targeted column → cursor on that row → lightbulb → "Fill empty cells with \"TODO\"" → cell becomes ` TODO `

## Notes

- Depends on the row-line precision introduced by #97/#98 — without that, TBL-002 Code Actions would target the wrong line.
- TBL-001 (add missing column), CTX-001 (placeholder replacement), REF-* (auto-fixes) are not mechanically safe to fix and remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)