### PR TITLE
feat(lsp): workspace-wide lint with in-memory document cache

### DIFF
--- a/packages/lsp-server/src/linter.test.ts
+++ b/packages/lsp-server/src/linter.test.ts
@@ -1,68 +1,132 @@
-import { describe, it, expect } from "bun:test";
-import { TextDocument } from "vscode-languageserver-textdocument";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { ContextlintConfig } from "@contextlint/core";
-import { lintBuffer } from "./linter.js";
+import { lintWorkspace } from "./linter.js";
+import { WorkspaceCache } from "./workspace.js";
 
-function md(content: string): TextDocument {
-  return TextDocument.create("file:///tmp/test.md", "markdown", 1, content);
-}
+let root: string;
 
-describe("lintBuffer", () => {
-  it("returns empty when no rules are configured", () => {
-    const doc = md("# Heading\n");
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "lint-ws-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("lintWorkspace", () => {
+  it("returns empty arrays for every file when no rules match", () => {
+    writeFileSync(join(root, "a.md"), "# A\n");
+    writeFileSync(join(root, "b.md"), "# B\n");
+    const cache = new WorkspaceCache();
+    cache.scan(root, ["**/*.md"]);
+
     const config: ContextlintConfig = { rules: [] };
-    expect(lintBuffer(doc, config)).toEqual([]);
+    const result = lintWorkspace(cache, config, root);
+
+    expect(result.size).toBe(2);
+    for (const messages of result.values()) {
+      expect(messages).toEqual([]);
+    }
   });
 
-  it("reports violations from a document-scope rule", () => {
-    const doc = md(`
-| Name | Age |
-|------|-----|
-| A    | 30  |
-`);
+  it("runs document-scope rules per file", () => {
+    writeFileSync(
+      join(root, "bad.md"),
+      "# Bad\n\n| Name | Age |\n|------|-----|\n| A    | 30  |\n",
+    );
+    writeFileSync(
+      join(root, "good.md"),
+      "# Good\n\n| ID | Status |\n|----|--------|\n| 1  | Done   |\n",
+    );
+    const cache = new WorkspaceCache();
+    cache.scan(root, ["**/*.md"]);
+
     const config: ContextlintConfig = {
       rules: [
-        {
-          rule: "tbl001",
-          options: { requiredColumns: ["ID", "Status"] },
-        },
+        { rule: "tbl001", options: { requiredColumns: ["ID", "Status"] } },
       ],
     };
-    const messages = lintBuffer(doc, config);
-    expect(messages.length).toBeGreaterThan(0);
-    expect(messages[0]?.ruleId).toBe("TBL-001");
+    const result = lintWorkspace(cache, config, root);
+
+    const badPath = [...result.keys()].find((k) => k.endsWith("/bad.md"));
+    const goodPath = [...result.keys()].find((k) => k.endsWith("/good.md"));
+    if (!badPath || !goodPath) throw new Error("expected both files cached");
+
+    expect(result.get(badPath)?.length ?? 0).toBeGreaterThan(0);
+    expect(result.get(badPath)?.[0]?.ruleId).toBe("TBL-001");
+    expect(result.get(goodPath)).toEqual([]);
   });
 
-  it("skips project-scope rules (e.g. STR-001) on a single buffer", () => {
-    const doc = md("# anything\n");
+  it("runs project-scope rules and attaches to file via filePath", () => {
+    // REF-002: REQ-02 defined in requirements.md but not referenced anywhere.
+    // Phase 4a attached the orphan warning to the defining file.
+    writeFileSync(
+      join(root, "requirements.md"),
+      "# Req\n\n| ID | Desc |\n|----|------|\n| REQ-01 | first |\n| REQ-02 | second |\n",
+    );
+    writeFileSync(
+      join(root, "spec.md"),
+      "# Spec\n\nImplements REQ-01.\n",
+    );
+    const cache = new WorkspaceCache();
+    cache.scan(root, ["**/*.md"]);
+
     const config: ContextlintConfig = {
       rules: [
         {
-          rule: "str001",
-          options: { files: ["docs/overview.md"] },
-        },
-      ],
-    };
-    expect(lintBuffer(doc, config)).toEqual([]);
-  });
-
-  it("respects the files option when filtering by filePath", () => {
-    const doc = md(`
-| Name | Age |
-|------|-----|
-| A    | 30  |
-`);
-    const config: ContextlintConfig = {
-      rules: [
-        {
-          rule: "tbl001",
+          rule: "ref002",
           options: {
-            requiredColumns: ["ID"],
-            files: "**/other.md",
+            definitions: "**/requirements.md",
+            references: ["**/spec.md"],
+            idColumn: "ID",
+            idPattern: "^REQ-\\d{2}$",
           },
         },
       ],
     };
-    expect(lintBuffer(doc, config)).toEqual([]);
+    const result = lintWorkspace(cache, config, root);
+
+    const reqPath = [...result.keys()].find((k) =>
+      k.endsWith("/requirements.md"),
+    );
+    if (!reqPath) throw new Error("expected requirements.md cached");
+
+    const msgs = result.get(reqPath) ?? [];
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]?.ruleId).toBe("REF-002");
+    expect(msgs[0]?.message).toContain("REQ-02");
+  });
+
+  it("reflects in-memory buffer updates (not on-disk content)", () => {
+    writeFileSync(
+      join(root, "a.md"),
+      "| Name | Age |\n|------|-----|\n| A    | 30  |\n",
+    );
+    const cache = new WorkspaceCache();
+    cache.scan(root, ["**/*.md"]);
+
+    const path = [...cache.documents().keys()][0];
+    if (!path) throw new Error("expected one cached file");
+
+    const config: ContextlintConfig = {
+      rules: [
+        { rule: "tbl001", options: { requiredColumns: ["ID"] } },
+      ],
+    };
+
+    // Initially bad
+    let result = lintWorkspace(cache, config, root);
+    expect(result.get(path)?.length ?? 0).toBeGreaterThan(0);
+
+    // Simulate editor fix via buffer update
+    cache.updateFromBuffer(
+      path,
+      "| ID | Age |\n|----|-----|\n| 1  | 30  |\n",
+    );
+    result = lintWorkspace(cache, config, root);
+    expect(result.get(path)).toEqual([]);
   });
 });

--- a/packages/lsp-server/src/linter.ts
+++ b/packages/lsp-server/src/linter.ts
@@ -1,3 +1,4 @@
+import { relative } from "node:path";
 import {
   parseDocument,
   resolveRule,
@@ -8,25 +9,62 @@ import type {
   LintMessage,
   Rule,
 } from "@contextlint/core";
-import type { TextDocument } from "vscode-languageserver-textdocument";
-import { uriToPath } from "./uri.js";
+import type { WorkspaceCache } from "./workspace.js";
 
 /**
- * Lint a single in-memory document using document-scope rules from the config.
- * Project-scope and cross-file rules are skipped — they need the full workspace,
- * which the LSP server does not currently re-read on every buffer change.
+ * Run the full lint pipeline (document-scope + project-scope rules)
+ * against every document in the workspace cache. Returns a per-file
+ * map of messages keyed by absolute file path. Files without any
+ * messages still have an empty-array entry so callers can publish
+ * diagnostics that clear stale violations.
+ *
+ * Project-scope messages without an explicit `filePath` go to the
+ * virtual `<project>` bucket.
  */
-export function lintBuffer(
-  document: TextDocument,
+export function lintWorkspace(
+  cache: WorkspaceCache,
   config: ContextlintConfig,
-): LintMessage[] {
-  const rules: Rule[] = config.rules
-    .map((entry) => resolveRule(entry.rule, entry.options))
-    .filter((rule) => (rule.scope ?? "document") === "document");
+  cwd: string,
+): Map<string, LintMessage[]> {
+  const rules: Rule[] = config.rules.map((entry) =>
+    resolveRule(entry.rule, entry.options),
+  );
+  const docRules = rules.filter((r) => (r.scope ?? "document") === "document");
+  const projectRules = rules.filter((r) => r.scope === "project");
 
-  if (rules.length === 0) return [];
+  const documents = cache.documents();
+  const projectFiles = [...documents.keys()].map((f) =>
+    relative(cwd, f).replace(/\\/g, "/"),
+  );
 
-  const parsed = parseDocument(document.getText());
-  const filePath = uriToPath(document.uri);
-  return runRules(rules, parsed, filePath);
+  const perFile = new Map<string, LintMessage[]>();
+  for (const filePath of documents.keys()) {
+    perFile.set(filePath, []);
+  }
+
+  const pushMsg = (key: string, msg: LintMessage): void => {
+    const arr = perFile.get(key) ?? [];
+    arr.push(msg);
+    perFile.set(key, arr);
+  };
+
+  if (projectRules.length > 0) {
+    const emptyDoc = parseDocument("");
+    const messages = runRules(projectRules, emptyDoc, "<project>", {
+      projectFiles,
+      documents,
+    });
+    for (const msg of messages) {
+      pushMsg(msg.filePath ?? "<project>", msg);
+    }
+  }
+
+  for (const [filePath, doc] of documents) {
+    const messages = runRules(docRules, doc, filePath, { documents });
+    for (const msg of messages) {
+      pushMsg(filePath, msg);
+    }
+  }
+
+  return perFile;
 }

--- a/packages/lsp-server/src/server.ts
+++ b/packages/lsp-server/src/server.ts
@@ -14,10 +14,15 @@ import { tryLoadConfig } from "./config-loader.js";
 import { provideCodeActions } from "./code-actions.js";
 import { toDiagnostics } from "./diagnostics.js";
 import { hoverForDiagnostics } from "./hover.js";
-import { lintBuffer } from "./linter.js";
+import { lintWorkspace } from "./linter.js";
 import { uriToPath } from "./uri.js";
+import { WorkspaceCache } from "./workspace.js";
 
-const DEBOUNCE_MS = 300;
+const DEBOUNCE_MS = 500;
+
+function pathToUri(filePath: string): string {
+  return `file://${filePath}`;
+}
 
 export function start(): void {
   const connection = createConnection(
@@ -29,8 +34,9 @@ export function start(): void {
 
   let loaded: LoadedConfig | null = null;
   let workspaceRoot: string = process.cwd();
-  const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const cache = new WorkspaceCache();
   const latestDiagnostics = new Map<string, Diagnostic[]>();
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   connection.onInitialize((params): InitializeResult => {
     const firstFolder = params.workspaceFolders?.[0];
@@ -38,6 +44,11 @@ export function start(): void {
       workspaceRoot = uriToPath(firstFolder.uri);
     }
     loaded = tryLoadConfig(workspaceRoot);
+    if (loaded) {
+      const patterns = loaded.config.include ?? ["**/*.md"];
+      cache.scan(workspaceRoot, patterns);
+      runLint();
+    }
     return {
       capabilities: {
         textDocumentSync: TextDocumentSyncKind.Incremental,
@@ -49,20 +60,15 @@ export function start(): void {
   });
 
   documents.onDidChangeContent((event) => {
-    scheduleLint(event.document);
+    const filePath = uriToPath(event.document.uri);
+    cache.updateFromBuffer(filePath, event.document.getText());
+    scheduleLint();
   });
 
-  documents.onDidClose((event) => {
-    const existing = debounceTimers.get(event.document.uri);
-    if (existing) {
-      clearTimeout(existing);
-      debounceTimers.delete(event.document.uri);
-    }
-    latestDiagnostics.delete(event.document.uri);
-    void connection.sendDiagnostics({
-      uri: event.document.uri,
-      diagnostics: [],
-    });
+  documents.onDidClose(() => {
+    // Keep the cache and diagnostics so Problems panel entries persist
+    // when the user closes the editor tab. The on-disk version will be
+    // picked up on the next `cache.scan` (e.g. workspace reload).
   });
 
   connection.onHover((params) => {
@@ -79,32 +85,48 @@ export function start(): void {
   documents.listen(connection);
   connection.listen();
 
-  function scheduleLint(document: TextDocument): void {
-    const existing = debounceTimers.get(document.uri);
-    if (existing) clearTimeout(existing);
-    const timer = setTimeout(() => {
-      debounceTimers.delete(document.uri);
-      runLint(document);
+  function scheduleLint(): void {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      runLint();
     }, DEBOUNCE_MS);
-    debounceTimers.set(document.uri, timer);
   }
 
-  function runLint(document: TextDocument): void {
-    if (!loaded) {
-      void connection.sendDiagnostics({ uri: document.uri, diagnostics: [] });
-      return;
-    }
-    let diagnostics: Diagnostic[];
+  function runLint(): void {
+    if (!loaded) return;
+
+    let perFileDiagnostics: Map<string, Diagnostic[]>;
     try {
-      const messages = lintBuffer(document, loaded.config);
-      diagnostics = toDiagnostics(messages);
+      const raw = lintWorkspace(cache, loaded.config, workspaceRoot);
+      perFileDiagnostics = new Map();
+      for (const [filePath, messages] of raw) {
+        if (filePath === "<project>") continue;
+        perFileDiagnostics.set(filePath, toDiagnostics(messages));
+      }
     } catch (error) {
       connection.console.error(
-        `contextlint: lint failed for ${document.uri}: ${String(error)}`,
+        `contextlint: lint failed: ${String(error)}`,
       );
-      diagnostics = [];
+      return;
     }
-    latestDiagnostics.set(document.uri, diagnostics);
-    void connection.sendDiagnostics({ uri: document.uri, diagnostics });
+
+    // Publish current diagnostics for every cached file (empty arrays
+    // clear stale violations the user just fixed).
+    for (const [filePath, diagnostics] of perFileDiagnostics) {
+      const uri = pathToUri(filePath);
+      latestDiagnostics.set(uri, diagnostics);
+      void connection.sendDiagnostics({ uri, diagnostics });
+    }
+
+    // Clear diagnostics for URIs that were tracked earlier but no longer
+    // appear in the lint result (e.g. a file was removed from the cache).
+    for (const uri of [...latestDiagnostics.keys()]) {
+      const filePath = uriToPath(uri);
+      if (!perFileDiagnostics.has(filePath)) {
+        latestDiagnostics.set(uri, []);
+        void connection.sendDiagnostics({ uri, diagnostics: [] });
+      }
+    }
   }
 }

--- a/packages/lsp-server/src/workspace.test.ts
+++ b/packages/lsp-server/src/workspace.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorkspaceCache } from "./workspace.js";
+
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ws-cache-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("WorkspaceCache", () => {
+  it("scan() populates the cache from files matching the patterns", () => {
+    writeFileSync(join(root, "a.md"), "# A\n");
+    writeFileSync(join(root, "b.md"), "# B\n");
+    writeFileSync(join(root, "ignore.txt"), "not md");
+
+    const cache = new WorkspaceCache();
+    cache.scan(root, ["**/*.md"]);
+
+    expect(cache.size()).toBe(2);
+    const keys = [...cache.documents().keys()].map(normalizePath).sort();
+    expect(keys[0]?.endsWith("/a.md")).toBe(true);
+    expect(keys[1]?.endsWith("/b.md")).toBe(true);
+  });
+
+  it("scan() respects subdirectories and glob exclusions", () => {
+    mkdirSync(join(root, "docs"), { recursive: true });
+    writeFileSync(join(root, "docs", "spec.md"), "# Spec\n");
+    writeFileSync(join(root, "README.md"), "# README\n");
+
+    const cache = new WorkspaceCache();
+    cache.scan(root, ["docs/**/*.md"]);
+
+    expect(cache.size()).toBe(1);
+    const keys = [...cache.documents().keys()].map(normalizePath);
+    expect(keys[0]?.endsWith("/docs/spec.md")).toBe(true);
+  });
+
+  it("updateFromBuffer() replaces the parsed document in memory", () => {
+    writeFileSync(join(root, "a.md"), "# A\n");
+    const cache = new WorkspaceCache();
+    cache.scan(root, ["**/*.md"]);
+
+    const path = [...cache.documents().keys()][0];
+    if (!path) throw new Error("expected one cached file");
+
+    const before = cache.documents().get(path);
+    expect(before?.content).toContain("# A");
+
+    cache.updateFromBuffer(path, "# Updated\n\n- new content\n");
+    const after = cache.documents().get(path);
+    expect(after?.content).toContain("# Updated");
+    expect(after?.content).toContain("new content");
+  });
+
+  it("updateFromBuffer() adds entries for unseen paths", () => {
+    const cache = new WorkspaceCache();
+    cache.updateFromBuffer("/tmp/never/scanned.md", "# Hello\n");
+    expect(cache.has("/tmp/never/scanned.md")).toBe(true);
+  });
+
+  it("delete() removes an entry from the cache", () => {
+    writeFileSync(join(root, "a.md"), "# A\n");
+    const cache = new WorkspaceCache();
+    cache.scan(root, ["**/*.md"]);
+
+    const path = [...cache.documents().keys()][0];
+    if (!path) throw new Error("expected one cached file");
+
+    cache.delete(path);
+    expect(cache.has(path)).toBe(false);
+    expect(cache.size()).toBe(0);
+  });
+
+  it("scan() clears prior entries before re-scanning", () => {
+    writeFileSync(join(root, "a.md"), "# A\n");
+    const cache = new WorkspaceCache();
+    cache.scan(root, ["**/*.md"]);
+    expect(cache.size()).toBe(1);
+
+    rmSync(join(root, "a.md"));
+    writeFileSync(join(root, "b.md"), "# B\n");
+    writeFileSync(join(root, "c.md"), "# C\n");
+    cache.scan(root, ["**/*.md"]);
+
+    expect(cache.size()).toBe(2);
+    expect(cache.has(join(root, "a.md").replace(/\\/g, "/"))).toBe(false);
+  });
+});

--- a/packages/lsp-server/src/workspace.ts
+++ b/packages/lsp-server/src/workspace.ts
@@ -1,0 +1,38 @@
+import { loadDocuments, parseDocument } from "@contextlint/core";
+import type { ParsedDocument } from "@contextlint/core";
+
+/**
+ * In-memory cache of parsed Markdown documents that make up the LSP
+ * workspace. Populated by `scan` on startup (from disk) and updated
+ * by `updateFromBuffer` when a file changes in the editor.
+ *
+ * Keys are absolute, forward-slash normalized file paths — matching
+ * the shape `@contextlint/core`'s `loadDocuments` produces.
+ */
+export class WorkspaceCache {
+  private docs: Map<string, ParsedDocument> = new Map();
+
+  scan(root: string, patterns: string[]): void {
+    this.docs = loadDocuments(patterns, root);
+  }
+
+  updateFromBuffer(filePath: string, content: string): void {
+    this.docs.set(filePath, parseDocument(content));
+  }
+
+  delete(filePath: string): void {
+    this.docs.delete(filePath);
+  }
+
+  documents(): Map<string, ParsedDocument> {
+    return this.docs;
+  }
+
+  size(): number {
+    return this.docs.size;
+  }
+
+  has(filePath: string): boolean {
+    return this.docs.has(filePath);
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the single-buffer lint with a workspace-scoped pipeline. On activation the LSP server scans all Markdown files matching `config.include`, parses them into a `WorkspaceCache`, and runs the full lint pipeline (document-scope **and** project-scope rules) across every cached document.

Editors now see cross-file diagnostics — **REF-001** broken links, **REF-002** unresolved IDs, **REF-003** stability, **TBL-006** duplicate IDs, **GRP-001/002/003** traceability / cycles / orphans, **CTX-002** glossary mismatches — directly on the violation's file and line, thanks to #102.

Part of #90 (Epic).
Closes #100.
Depends on #102 (merged).

## Changes

- **New module** `packages/lsp-server/src/workspace.ts` — `WorkspaceCache` class:
  - `scan(root, patterns)` loads and parses every matching file via `@contextlint/core`'s `loadDocuments`.
  - `updateFromBuffer(path, content)` re-parses the in-memory buffer, overriding the on-disk version.
  - `delete` / `has` / `size` / `documents()` for housekeeping.
- **`linter.ts`** now exports `lintWorkspace(cache, config, cwd)` returning `Map<absPath, LintMessage[]>`. The single-buffer `lintBuffer` is removed.
- **`server.ts`**:
  - `onInitialize`: scan the workspace, run an initial lint, publish diagnostics per file.
  - `onDidChangeContent`: update cache from buffer, debounced (500 ms) workspace re-lint, republish.
  - `onDidClose`: cache and diagnostics persist (so Problems panel entries keep working).
  - Diagnostics for files no longer in the cache are cleared explicitly.
- **Tests**: `workspace.test.ts` + rewritten `linter.test.ts` covering scan/update/delete/re-scan, document-scope, project-scope (via #102), and buffer-vs-disk precedence.

## Out of scope (future waves)

- `workspace/didChangeWatchedFiles` for files changed outside the LSP session. Workaround: `Cmd+R` (Reload Window) re-scans.
- Cache eviction / memory limits. Workaround: same.
- Tiered diagnostics (fast on-type, deep on-save).
- True incremental parsing (mdast re-parses whole documents).

## Test plan

- [x] `bun run --filter '*' build` — 5 packages
- [x] `bun run --filter '*' typecheck` — pass
- [x] `bun test` — 763 / 763 pass (6 new for workspace + rewritten linter tests)
- [x] `npx eslint .` — 0 errors
- [x] Manual EDH verification with a cross-file fixture (REF-001 broken link, fix inline → diagnostic disappears without reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)