### PR TITLE
docs: add LSP setup snippets for Neovim, Helix, and JetBrains editors

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -450,6 +450,73 @@ npm install -D @contextlint/mcp-server
 | `impact-analysis` | 指定ファイルの変更がどのドキュメントに影響するかを分析する |
 | `compile-context` | ドキュメント構造を LLM 向けコンテキストテキストにコンパイルする |
 
+## LSP サーバー
+
+contextlint には Language Server (`@contextlint/lsp-server`) が含まれており、
+LSP 対応のエディタであればエディタ内での診断、ホバー情報、Quick Fix を利用できます。
+サーバーは workspace ルートから親ディレクトリへと遡って `contextlint.config.json`
+を探します（CLI / MCP と同じ挙動）。
+
+> VS Code / Cursor 向けの専用拡張機能は別途開発中で、将来 Marketplace に公開予定です。
+> 現時点では、以下のスニペットで LSP を話すすべてのエディタに組み込めます。
+
+インストール:
+
+```bash
+npm install -D @contextlint/lsp-server
+```
+
+### Neovim ([nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) 使用時)
+
+```lua
+-- init.lua または after/plugin/contextlint.lua 内
+local configs = require('lspconfig.configs')
+local util = require('lspconfig.util')
+
+if not configs.contextlint then
+  configs.contextlint = {
+    default_config = {
+      cmd = { 'npx', 'contextlint-lsp' },
+      filetypes = { 'markdown' },
+      root_dir = util.root_pattern('contextlint.config.json', '.git'),
+      single_file_support = false,
+    },
+  }
+end
+
+require('lspconfig').contextlint.setup({})
+```
+
+### Helix (`~/.config/helix/languages.toml`)
+
+```toml
+[language-server.contextlint]
+command = "npx"
+args = ["contextlint-lsp"]
+
+[[language]]
+name = "markdown"
+language-servers = ["contextlint"]
+```
+
+### JetBrains IDE ([LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) 経由)
+
+1. Marketplace から **LSP4IJ** プラグインをインストールします。
+2. **Settings → Languages & Frameworks → Language Servers → Add** を開いて設定:
+   - **Name**: `contextlint`
+   - **Command**: `npx contextlint-lsp`
+   - **Mapping → File name patterns**: `*.md`
+
+### 補足
+
+- 診断はドキュメントスコープのルール（TBL-002, CHK-001 など）と
+  プロジェクトスコープのルール（REF-001, REF-002, TBL-006, GRP-001/002/003,
+  CTX-002 など）の両方を、ワークスペース全体に対して編集中にリアルタイムで適用します。
+- Quick Fix は現在 **CHK-001**（チェックリスト項目をチェック）と
+  **TBL-002**（空セルに `TODO` を挿入）に対応しています。
+- `git pull` など外部でのファイル変更の後は、エディタウィンドウをリロードすると
+  ワークスペースキャッシュが更新されます。
+
 ## プログラマティック API
 
 ### コンテキストグラフ

--- a/README.ko.md
+++ b/README.ko.md
@@ -447,6 +447,74 @@ npm install -D @contextlint/mcp-server
 | `impact-analysis` | 지정 파일의 변경이 어떤 문서에 영향을 미치는지 분석 |
 | `compile-context` | 문서 구조를 LLM 컨텍스트 텍스트로 컴파일 |
 
+## LSP 서버
+
+contextlint에는 Language Server (`@contextlint/lsp-server`)가 포함되어 있어,
+LSP를 지원하는 모든 에디터에서 에디터 내 진단, 호버 정보, Quick Fix를 사용할 수
+있습니다. 서버는 워크스페이스 루트에서 상위로 거슬러 올라가며
+`contextlint.config.json`을 찾습니다 (CLI / MCP와 동일한 동작).
+
+> 전용 VS Code / Cursor 확장은 별도로 진행 중이며 향후 Marketplace에 게시될
+> 예정입니다. 현재는 아래 스니펫을 통해 LSP를 지원하는 모든 에디터에서
+> 동작합니다.
+
+설치:
+
+```bash
+npm install -D @contextlint/lsp-server
+```
+
+### Neovim ([nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) 사용 시)
+
+```lua
+-- init.lua 또는 after/plugin/contextlint.lua 에서
+local configs = require('lspconfig.configs')
+local util = require('lspconfig.util')
+
+if not configs.contextlint then
+  configs.contextlint = {
+    default_config = {
+      cmd = { 'npx', 'contextlint-lsp' },
+      filetypes = { 'markdown' },
+      root_dir = util.root_pattern('contextlint.config.json', '.git'),
+      single_file_support = false,
+    },
+  }
+end
+
+require('lspconfig').contextlint.setup({})
+```
+
+### Helix (`~/.config/helix/languages.toml`)
+
+```toml
+[language-server.contextlint]
+command = "npx"
+args = ["contextlint-lsp"]
+
+[[language]]
+name = "markdown"
+language-servers = ["contextlint"]
+```
+
+### JetBrains IDE ([LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) 경유)
+
+1. Marketplace에서 **LSP4IJ** 플러그인을 설치합니다.
+2. **Settings → Languages & Frameworks → Language Servers → Add** 를 열고 설정:
+   - **Name**: `contextlint`
+   - **Command**: `npx contextlint-lsp`
+   - **Mapping → File name patterns**: `*.md`
+
+### 참고
+
+- 진단은 문서 범위 규칙 (TBL-002, CHK-001 등)과 프로젝트 범위 규칙
+  (REF-001, REF-002, TBL-006, GRP-001/002/003, CTX-002 등)을 모두 포함하여
+  워크스페이스 전체에 실시간으로 적용됩니다.
+- Quick Fix는 현재 **CHK-001** (체크리스트 항목 체크)과
+  **TBL-002** (빈 셀에 `TODO` 삽입)을 지원합니다.
+- `git pull` 등 외부 파일 변경 후에는 에디터 창을 다시 로드하면 워크스페이스
+  캐시가 갱신됩니다.
+
 ## 프로그래밍 API
 
 ### 컨텍스트 그래프

--- a/README.md
+++ b/README.md
@@ -440,6 +440,75 @@ Available tools:
 | `impact-analysis` | Analyze which documents are affected by changes to a given file |
 | `compile-context` | Compile document structure into LLM context text |
 
+## LSP Server
+
+contextlint ships a Language Server (`@contextlint/lsp-server`) that
+any LSP-capable editor can integrate for in-editor diagnostics, hover
+info, and Quick Fixes. The server walks up from the workspace root to
+discover `contextlint.config.json`, matching the CLI / MCP behaviour.
+
+> A dedicated VS Code / Cursor extension is tracked separately and
+> will be published to the Marketplace in a future release. For now,
+> the snippets below work in every editor that speaks LSP.
+
+Install:
+
+```bash
+npm install -D @contextlint/lsp-server
+```
+
+### Neovim (with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig))
+
+```lua
+-- In your init.lua or after/plugin/contextlint.lua
+local configs = require('lspconfig.configs')
+local util = require('lspconfig.util')
+
+if not configs.contextlint then
+  configs.contextlint = {
+    default_config = {
+      cmd = { 'npx', 'contextlint-lsp' },
+      filetypes = { 'markdown' },
+      root_dir = util.root_pattern('contextlint.config.json', '.git'),
+      single_file_support = false,
+    },
+  }
+end
+
+require('lspconfig').contextlint.setup({})
+```
+
+### Helix (`~/.config/helix/languages.toml`)
+
+```toml
+[language-server.contextlint]
+command = "npx"
+args = ["contextlint-lsp"]
+
+[[language]]
+name = "markdown"
+language-servers = ["contextlint"]
+```
+
+### JetBrains IDEs (via [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij))
+
+1. Install the **LSP4IJ** plugin from the Marketplace.
+2. Open **Settings → Languages & Frameworks → Language Servers → Add**:
+   - **Name**: `contextlint`
+   - **Command**: `npx contextlint-lsp`
+   - **Mapping → File name patterns**: `*.md`
+
+### Notes
+
+- Diagnostics cover both document-scope rules (TBL-002, CHK-001, …)
+  and project-scope rules (REF-001, REF-002, TBL-006,
+  GRP-001/002/003, CTX-002, …) across the entire workspace, in real
+  time as you edit.
+- Quick Fixes are available for **CHK-001** (check the list item) and
+  **TBL-002** (insert a `TODO` placeholder).
+- After external file changes (e.g. `git pull`), reload the editor
+  window to refresh the workspace cache.
+
 ## Programmatic API
 
 ### Context Graph

--- a/README.zh.md
+++ b/README.zh.md
@@ -435,6 +435,71 @@ npm install -D @contextlint/mcp-server
 | `impact-analysis` | 分析指定文件的更改会影响哪些文档 |
 | `compile-context` | 将文档结构编译为 LLM 上下文文本 |
 
+## LSP 服务器
+
+contextlint 自带 Language Server (`@contextlint/lsp-server`)，任何支持 LSP 的编辑器
+都可以集成以获得编辑器内的诊断、悬停信息和 Quick Fix。服务器会从工作区根目录向上
+查找 `contextlint.config.json`（与 CLI / MCP 行为一致）。
+
+> 专门的 VS Code / Cursor 扩展正在独立开发中，将在未来发布到 Marketplace。
+> 目前，下面的代码片段可在所有支持 LSP 的编辑器中使用。
+
+安装:
+
+```bash
+npm install -D @contextlint/lsp-server
+```
+
+### Neovim (搭配 [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig))
+
+```lua
+-- 在 init.lua 或 after/plugin/contextlint.lua 中
+local configs = require('lspconfig.configs')
+local util = require('lspconfig.util')
+
+if not configs.contextlint then
+  configs.contextlint = {
+    default_config = {
+      cmd = { 'npx', 'contextlint-lsp' },
+      filetypes = { 'markdown' },
+      root_dir = util.root_pattern('contextlint.config.json', '.git'),
+      single_file_support = false,
+    },
+  }
+end
+
+require('lspconfig').contextlint.setup({})
+```
+
+### Helix (`~/.config/helix/languages.toml`)
+
+```toml
+[language-server.contextlint]
+command = "npx"
+args = ["contextlint-lsp"]
+
+[[language]]
+name = "markdown"
+language-servers = ["contextlint"]
+```
+
+### JetBrains IDE (通过 [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij))
+
+1. 从 Marketplace 安装 **LSP4IJ** 插件。
+2. 打开 **Settings → Languages & Frameworks → Language Servers → Add** 并配置:
+   - **Name**: `contextlint`
+   - **Command**: `npx contextlint-lsp`
+   - **Mapping → File name patterns**: `*.md`
+
+### 说明
+
+- 诊断覆盖文档作用域规则（TBL-002、CHK-001 等）和项目作用域规则
+  （REF-001、REF-002、TBL-006、GRP-001/002/003、CTX-002 等），作用于整个工作区，
+  在编辑过程中实时更新。
+- Quick Fix 目前支持 **CHK-001**（勾选清单项）和
+  **TBL-002**（向空单元格插入 `TODO`）。
+- 在外部文件变更（例如 `git pull`）之后，重新加载编辑器窗口即可刷新工作区缓存。
+
 ## 编程式 API
 
 ### 上下文图


### PR DESCRIPTION
## Summary

Adds a new **LSP Server** section to all four README variants (`README.md`, `README.ja.md`, `README.zh.md`, `README.ko.md`) so users of editors beyond VS Code / Cursor can discover and configure `@contextlint/lsp-server`.

Part of #90 (Epic).
Closes #104.

## What's new

Copy-pastable snippets for:

- **Neovim** (via [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) with a custom server registration)
- **Helix** (via `languages.toml`)
- **JetBrains IDEs** (via the [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin)

Plus supporting notes:

- Config discovery walks up from the workspace root — same behavior as CLI / MCP / VS Code.
- Diagnostics cover both document-scope and project-scope rules across the entire workspace, in real time.
- Quick Fixes available today: CHK-001, TBL-002.
- `Cmd+R` (Reload Window) refreshes the cache after external file changes (e.g. `git pull`).

## Scope

Docs-only. No code changes in `@contextlint/core`, `lsp-server`, `cli`, `mcp-server`, or `contextlint-vscode`.

## Test plan

- [x] `bunx markdownlint-cli2 "README*.md"` — 0 errors
- [x] `bun run --filter '*' build` — all 5 packages
- [x] `bun run --filter '*' typecheck` — pass
- [x] `bun test` — 763 / 763 pass
- [x] `npx eslint .` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)