### PR TITLE
chore: post-v0.9.0 publish housekeeping

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Publish to npm
         run: |
           for pkg in packages/*/; do
+            if [ "$(jq -r '.private // false' "$pkg/package.json")" = "true" ]; then
+              echo "Skipping private package: $pkg"
+              continue
+            fi
             (cd "$pkg" && bun publish --no-git-checks --access public)
           done
         env:

--- a/README.ja.md
+++ b/README.ja.md
@@ -7,6 +7,7 @@
 [![npm version](https://img.shields.io/npm/v/@contextlint/cli.svg)](https://www.npmjs.com/package/@contextlint/cli)
 [![cli downloads](https://img.shields.io/npm/dm/@contextlint/cli.svg?label=cli%20downloads)](https://www.npmjs.com/package/@contextlint/cli)
 [![mcp-server downloads](https://img.shields.io/npm/dm/@contextlint/mcp-server.svg?label=mcp-server%20downloads)](https://www.npmjs.com/package/@contextlint/mcp-server)
+[![lsp-server downloads](https://img.shields.io/npm/dm/@contextlint/lsp-server.svg?label=lsp-server%20downloads)](https://www.npmjs.com/package/@contextlint/lsp-server)
 [![CI](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,6 +7,7 @@
 [![npm version](https://img.shields.io/npm/v/@contextlint/cli.svg)](https://www.npmjs.com/package/@contextlint/cli)
 [![cli downloads](https://img.shields.io/npm/dm/@contextlint/cli.svg?label=cli%20downloads)](https://www.npmjs.com/package/@contextlint/cli)
 [![mcp-server downloads](https://img.shields.io/npm/dm/@contextlint/mcp-server.svg?label=mcp-server%20downloads)](https://www.npmjs.com/package/@contextlint/mcp-server)
+[![lsp-server downloads](https://img.shields.io/npm/dm/@contextlint/lsp-server.svg?label=lsp-server%20downloads)](https://www.npmjs.com/package/@contextlint/lsp-server)
 [![CI](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![npm version](https://img.shields.io/npm/v/@contextlint/cli.svg)](https://www.npmjs.com/package/@contextlint/cli)
 [![cli downloads](https://img.shields.io/npm/dm/@contextlint/cli.svg?label=cli%20downloads)](https://www.npmjs.com/package/@contextlint/cli)
 [![mcp-server downloads](https://img.shields.io/npm/dm/@contextlint/mcp-server.svg?label=mcp-server%20downloads)](https://www.npmjs.com/package/@contextlint/mcp-server)
+[![lsp-server downloads](https://img.shields.io/npm/dm/@contextlint/lsp-server.svg?label=lsp-server%20downloads)](https://www.npmjs.com/package/@contextlint/lsp-server)
 [![CI](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,6 +7,7 @@
 [![npm version](https://img.shields.io/npm/v/@contextlint/cli.svg)](https://www.npmjs.com/package/@contextlint/cli)
 [![cli downloads](https://img.shields.io/npm/dm/@contextlint/cli.svg?label=cli%20downloads)](https://www.npmjs.com/package/@contextlint/cli)
 [![mcp-server downloads](https://img.shields.io/npm/dm/@contextlint/mcp-server.svg?label=mcp-server%20downloads)](https://www.npmjs.com/package/@contextlint/mcp-server)
+[![lsp-server downloads](https://img.shields.io/npm/dm/@contextlint/lsp-server.svg?label=lsp-server%20downloads)](https://www.npmjs.com/package/@contextlint/lsp-server)
 [![CI](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 


### PR DESCRIPTION
Two small cleanups following the v0.9.0 release.

## 1. `fix(ci)`: skip private packages during npm publish

`contextlint-vscode` is marked `"private": true` because it targets the VS Code Marketplace, not npm. The previous `publish.yml` iterated over every workspace and called `bun publish`, so when `v0.9.0` was tagged the loop hit `error: attempted to publish a private package` on `contextlint-vscode` and exited non-zero — **after the four real packages had already published successfully**.

```yaml
      - name: Publish to npm
        run: |
          for pkg in packages/*/; do
+           if [ "$(jq -r '.private // false' "$pkg/package.json")" = "true" ]; then
+             echo "Skipping private package: $pkg"
+             continue
+           fi
            (cd "$pkg" && bun publish --no-git-checks --access public)
          done
```

`jq` is preinstalled on `ubuntu-latest` — no new dependency. Verified locally:

```
$ jq -r '.private // false' packages/vscode/package.json  # → true
$ jq -r '.private // false' packages/core/package.json    # → false
```

## 2. `docs`: add npm badge for `@contextlint/lsp-server`

`@contextlint/lsp-server` first shipped in v0.9.0. Adds its downloads badge to all four README variants (EN / JA / ZH / KO), next to the existing `cli` and `mcp-server` badges.

## Notes

- Does **not** retroactively fix the v0.9.0 CI run. Every future tag push will finish green.
- v0.9.0 is already live on npm for the four real packages.

## Test plan

- [x] `bunx markdownlint-cli2 "README*.md"` — 0 errors
- [x] `bun run --filter '*' build` — all 5 packages
- [x] `bun test` — 763 / 763 pass
- [x] `npx eslint .` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)