### PR TITLE
Attach VSIX builds to GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v6
@@ -25,6 +25,7 @@ jobs:
       - name: Set version and resolve workspace dependencies
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
           for pkg in packages/*/; do
             (cd "$pkg" && npm pkg set "version=${VERSION}")
           done
@@ -41,3 +42,24 @@ jobs:
           done
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Package VS Code extension
+        working-directory: packages/vscode
+        run: |
+          for attempt in 1 2 3; do
+            if npm install --omit=dev --ignore-scripts --package-lock=false; then
+              break
+            fi
+            if [ "$attempt" = "3" ]; then
+              exit 1
+            fi
+            sleep 10
+          done
+          npx --yes @vscode/vsce package \
+            --out "../../contextlint-vscode-${VERSION}.vsix"
+
+      - name: Attach VSIX to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: contextlint-vscode-*.vsix
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
+*.vsix
 *.tsbuildinfo
 .DS_Store

--- a/README.ja.md
+++ b/README.ja.md
@@ -461,6 +461,25 @@ LSP 対応のエディタであればエディタ内での診断、ホバー情�
 > VS Code / Cursor 向けの専用拡張機能は別途開発中で、将来 Marketplace に公開予定です。
 > 現時点では、以下のスニペットで LSP を話すすべてのエディタに組み込めます。
 
+### Marketplace を使わずに VS Code / Cursor へ導入する
+
+VSIX が添付されているリリースでは、GitHub Release から
+`contextlint-vscode-*.vsix` をダウンロードし、手動でインストールできます。
+
+1. Extensions ビューを開きます。
+2. **Views and More Actions...** を選択します。
+3. **Install from VSIX...** を選択します。
+4. ダウンロードした `.vsix` ファイルを選択します。
+
+コマンドラインからインストールすることもできます:
+
+```bash
+code --install-extension contextlint-vscode-VERSION.vsix
+```
+
+拡張機能は Markdown ファイルに対して `@contextlint/lsp-server` を自動起動し、
+最寄りの `contextlint.config.json` を使用します。
+
 インストール:
 
 ```bash
@@ -649,6 +668,8 @@ CI パイプラインに追加して、SKILL.md をドキュメントと同期�
 | `@contextlint/core` | ルールエンジンと Markdown パーサー |
 | `@contextlint/cli` | CLI エントリーポイント（`contextlint`コマンド） |
 | `@contextlint/mcp-server` | AI ツール連携用の MCP サーバー |
+| `@contextlint/lsp-server` | Language Server Protocol 実装 |
+| `contextlint-vscode` | VSIX として配布する VS Code / Cursor 拡張 |
 
 ## 関連記事
 

--- a/README.md
+++ b/README.md
@@ -452,6 +452,26 @@ discover `contextlint.config.json`, matching the CLI / MCP behaviour.
 > will be published to the Marketplace in a future release. For now,
 > the snippets below work in every editor that speaks LSP.
 
+### VS Code / Cursor without Marketplace
+
+For releases that provide a VSIX asset, download
+`contextlint-vscode-*.vsix` from the GitHub Release and install it
+manually:
+
+1. Open the Extensions view.
+2. Select **Views and More Actions...**.
+3. Select **Install from VSIX...**.
+4. Choose the downloaded `.vsix` file.
+
+Or install it from the command line:
+
+```bash
+code --install-extension contextlint-vscode-VERSION.vsix
+```
+
+The extension starts `@contextlint/lsp-server` automatically for
+Markdown files and uses the nearest `contextlint.config.json`.
+
 Install:
 
 ```bash
@@ -642,6 +662,8 @@ Add to your CI pipeline to keep SKILL.md in sync with documentation:
 | `@contextlint/core` | Rule engine and Markdown parser |
 | `@contextlint/cli` | CLI entry point (`contextlint` command) |
 | `@contextlint/mcp-server` | MCP server for AI tool integration |
+| `@contextlint/lsp-server` | Language Server Protocol implementation |
+| `contextlint-vscode` | VS Code / Cursor extension distributed as VSIX |
 
 ## Resources
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,0 +1,26 @@
+# contextlint for VS Code and Cursor
+
+In-editor diagnostics for structured Markdown documents powered by
+`@contextlint/lsp-server`.
+
+## Install from VSIX
+
+Download `contextlint-vscode-*.vsix` from the GitHub Release for the
+version you want to use, then install it manually.
+
+In VS Code or Cursor:
+
+1. Open the Extensions view.
+2. Select **Views and More Actions...**.
+3. Select **Install from VSIX...**.
+4. Choose the downloaded `.vsix` file.
+
+From the command line:
+
+```bash
+code --install-extension contextlint-vscode-VERSION.vsix
+```
+
+After installation, open a workspace containing `contextlint.config.json`
+and edit a Markdown file. Diagnostics, hover info, and supported Quick
+Fixes will be provided through the contextlint language server.


### PR DESCRIPTION
## Summary
- Package the VS Code/Cursor extension as a VSIX during tagged releases.
- Attach the generated VSIX to the GitHub Release so users can install contextlint without Marketplace distribution.
- Document manual VSIX installation for VS Code and Cursor in English and Japanese docs.

## Test plan
- Verified workflow YAML parses locally.
- Ran `git diff --check`.
- Checked edited files with IDE diagnostics.
- Not run: full `bun test` or local VSIX packaging because `bun` is not installed in this environment.