### PR TITLE
fix(ci): build VSIX in clean temp directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,8 +44,12 @@ jobs:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Package VS Code extension
-        working-directory: packages/vscode
         run: |
+          package_dir="$(mktemp -d)"
+          cp -R packages/vscode/. "$package_dir/"
+          cd "$package_dir"
+          npm pkg set "version=${VERSION}"
+          npm pkg set "dependencies.@contextlint/lsp-server=${VERSION}"
           for attempt in 1 2 3; do
             if npm install --omit=dev --ignore-scripts --package-lock=false; then
               break
@@ -56,7 +60,7 @@ jobs:
             sleep 10
           done
           npx --yes @vscode/vsce package \
-            --out "../../contextlint-vscode-${VERSION}.vsix"
+            --out "${GITHUB_WORKSPACE}/contextlint-vscode-${VERSION}.vsix"
 
       - name: Attach VSIX to GitHub Release
         uses: softprops/action-gh-release@v3

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -1,0 +1,2 @@
+src/**
+tsconfig.json


### PR DESCRIPTION
## Summary

- Build the VS Code extension VSIX in an isolated temp directory instead of directly in `packages/vscode/`, avoiding workspace pollution and conflicts with bun-managed `node_modules`
- Add `.vscodeignore` to exclude `src/` and `tsconfig.json` from the packaged VSIX

🤖 Generated with [Claude Code](https://claude.com/claude-code)