### PR TITLE
fix(ci): use local tarballs for VSIX packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,18 +47,13 @@ jobs:
         run: |
           package_dir="$(mktemp -d)"
           cp -R packages/vscode/. "$package_dir/"
+          npm pack --pack-destination "$package_dir" ./packages/core
+          npm pack --pack-destination "$package_dir" ./packages/lsp-server
           cd "$package_dir"
           npm pkg set "version=${VERSION}"
-          npm pkg set "dependencies.@contextlint/lsp-server=${VERSION}"
-          for attempt in 1 2 3; do
-            if npm install --omit=dev --ignore-scripts --package-lock=false; then
-              break
-            fi
-            if [ "$attempt" = "3" ]; then
-              exit 1
-            fi
-            sleep 10
-          done
+          npm pkg set "dependencies.@contextlint/lsp-server=./contextlint-lsp-server-${VERSION}.tgz"
+          npm pkg set "overrides.@contextlint/core=./contextlint-core-${VERSION}.tgz"
+          npm install --omit=dev --ignore-scripts --package-lock=false
           npx --yes @vscode/vsce package \
             --out "${GITHUB_WORKSPACE}/contextlint-vscode-${VERSION}.vsix"
 


### PR DESCRIPTION
## Summary

- Use `npm pack` to create local tarballs of `@contextlint/core` and `@contextlint/lsp-server` instead of fetching from the npm registry
- Resolves VSIX packaging failure caused by npm registry propagation delay (#108)

## What changed

The VSIX build step now:
1. Packs the locally built workspace packages as tarballs
2. Points `dependencies` and `overrides` to those local tarballs
3. Runs `npm install` which resolves workspace packages locally and external packages from npm

This removes the retry loop entirely — no registry dependency means no propagation race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)