### PR TITLE
chore: declare packageManager as bun for Cloudflare Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "contextlint",
   "private": true,
   "description": "Rule-based linter for structured Markdown documents",
+  "packageManager": "bun@1.3.10",
   "workspaces": ["packages/*"],
   "scripts": {
     "build": "bun run --filter '*' build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "contextlint",
   "private": true,
   "description": "Rule-based linter for structured Markdown documents",
-  "packageManager": "bun@1.3.10",
+  "packageManager": "bun@1.3.13",
   "workspaces": ["packages/*"],
   "scripts": {
     "build": "bun run --filter '*' build",


### PR DESCRIPTION
## Summary
- Add `"packageManager": "bun@1.3.10"` to root `package.json`
- Cloudflare Pages defaults to npm and fails on bun workspace's `workspace:*` notation (`EUNSUPPORTEDPROTOCOL`); declaring bun explicitly tells the build pipeline to use the right package manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)