### PR TITLE
fix(site): prevent horizontal overflow on narrow viewports

### DIFF
--- a/packages/site/src/components/Integrations.astro
+++ b/packages/site/src/components/Integrations.astro
@@ -25,7 +25,7 @@ const groups = [
         <div class="sct-numeral">§ 006</div>
         <div class="sct-numeral mt-1 opacity-60">// INTEGRATIONS</div>
       </div>
-      <div class="md:col-span-9">
+      <div class="md:col-span-9 min-w-0">
         <h2 class="display-l">
           Plugs into the<br />
           <span class="text-accent">tools you already use.</span>

--- a/packages/site/src/components/Problem.astro
+++ b/packages/site/src/components/Problem.astro
@@ -8,7 +8,7 @@
         <div class="sct-numeral">§ 001</div>
         <div class="sct-numeral mt-1 opacity-60">// THE PROBLEM</div>
       </div>
-      <div class="md:col-span-9">
+      <div class="md:col-span-9 min-w-0">
         <h2 class="display-l">
           The doc graph is too big to lint by eye.
         </h2>

--- a/packages/site/src/components/QuickStart.astro
+++ b/packages/site/src/components/QuickStart.astro
@@ -8,7 +8,7 @@
         <div class="sct-numeral">§ 005</div>
         <div class="sct-numeral mt-1 opacity-60">// QUICK START</div>
       </div>
-      <div class="md:col-span-9">
+      <div class="md:col-span-9 min-w-0">
         <h2 class="display-l">
           From zero to <span class="text-accent">first lint</span><br />
           in two commands.

--- a/packages/site/src/components/Solution.astro
+++ b/packages/site/src/components/Solution.astro
@@ -14,7 +14,7 @@ const principles = [
         <div class="sct-numeral">§ 002</div>
         <div class="sct-numeral mt-1 opacity-60">// THE APPROACH</div>
       </div>
-      <div class="md:col-span-9">
+      <div class="md:col-span-9 min-w-0">
         <h2 class="display-l">
           Generation is creative.<br />
           <span class="text-accent">Verification should not be.</span>

--- a/packages/site/src/components/ThreeLayer.astro
+++ b/packages/site/src/components/ThreeLayer.astro
@@ -31,7 +31,7 @@ const layers = [
         <div class="sct-numeral">§ 003</div>
         <div class="sct-numeral mt-1 opacity-60">// CHECKPOINTS</div>
       </div>
-      <div class="md:col-span-9">
+      <div class="md:col-span-9 min-w-0">
         <h2 class="display-l">
           One linter,<br />
           <span class="text-accent">three checkpoints.</span>

--- a/packages/site/src/components/WhatItCatches.astro
+++ b/packages/site/src/components/WhatItCatches.astro
@@ -74,7 +74,7 @@ data-model.md    →  architecture.md`,
         <div class="sct-numeral">§ 004</div>
         <div class="sct-numeral mt-1 opacity-60">// INSPECTION</div>
       </div>
-      <div class="md:col-span-9">
+      <div class="md:col-span-9 min-w-0">
         <h2 class="display-l">
           Six examples.<br />
           <span class="text-accent">Twenty-one rules.</span>

--- a/packages/site/src/components/WhyThisExists.astro
+++ b/packages/site/src/components/WhyThisExists.astro
@@ -8,7 +8,7 @@
         <div class="sct-numeral">§ 007</div>
         <div class="sct-numeral mt-1 opacity-60">// ORIGIN</div>
       </div>
-      <div class="md:col-span-9">
+      <div class="md:col-span-9 min-w-0">
         <h2 class="display-l">
           Built from <span class="text-accent">lived practice.</span>
         </h2>

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -56,6 +56,11 @@
     font-feature-settings: "calt", "ss01";
   }
 
+  pre {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
   hr {
     border: 0;
     border-top: 1px solid var(--color-rule);


### PR DESCRIPTION
## Summary
- Quick Start config callout's long `\$schema` URL caused horizontal scrolling on mobile
- Add `pre { max-width: 100%; overflow-x: auto }` in base layer so long code scrolls within its container
- Add `min-w-0` to all `md:col-span-9` grid items so CSS Grid children stop expanding to content size

🤖 Generated with [Claude Code](https://claude.com/claude-code)