### PR TITLE
fix(site): add explicit grid-cols-1 for mobile layout

### DIFF
--- a/packages/site/src/components/Integrations.astro
+++ b/packages/site/src/components/Integrations.astro
@@ -37,9 +37,9 @@ const groups = [
       </div>
     </div>
 
-    <div class="grid md:grid-cols-3 border border-ink">
+    <div class="grid grid-cols-1 md:grid-cols-3 border border-ink">
       {groups.map((g, i) => (
-        <div class={`pt-7 pb-7 px-6 ${i > 0 ? 'md:border-l md:border-ink border-t md:border-t-0 border-ink' : ''}`}>
+        <div class={`pt-7 pb-7 px-6 min-w-0 ${i > 0 ? 'md:border-l md:border-ink border-t md:border-t-0 border-ink' : ''}`}>
           <div class="flex items-baseline gap-3 mb-5 pb-3 border-b border-rule">
             <h3 class="display-m">{g.title}</h3>
             <span class="font-mono text-[0.7rem] text-mute">[{g.proto}]</span>

--- a/packages/site/src/components/QuickStart.astro
+++ b/packages/site/src/components/QuickStart.astro
@@ -14,13 +14,13 @@
           in two commands.
         </h2>
 
-        <div class="grid md:grid-cols-2 gap-px mt-12 border border-ink" style="background: var(--color-ink);">
-          <div class="bg-paper p-6 md:p-7">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-px mt-12 border border-ink" style="background: var(--color-ink);">
+          <div class="bg-paper p-6 md:p-7 min-w-0">
             <div class="sct-numeral mb-4">[step.01] // install</div>
             <pre class="font-mono text-sm p-4 overflow-x-auto" style="background: var(--color-ink); color: var(--color-paper);"><code>npm install -D @contextlint/cli</code></pre>
             <p class="text-xs text-mute mt-3 font-mono">// or: bunx, pnpm, yarn</p>
           </div>
-          <div class="bg-paper p-6 md:p-7">
+          <div class="bg-paper p-6 md:p-7 min-w-0">
             <div class="sct-numeral mb-4">[step.02] // lint</div>
             <pre class="font-mono text-sm p-4 overflow-x-auto" style="background: var(--color-ink); color: var(--color-paper);"><code>npx contextlint "**/*.md"</code></pre>
             <p class="text-xs text-mute mt-3 font-mono">// add a config file to enable cross-file rules</p>

--- a/packages/site/src/components/WhatItCatches.astro
+++ b/packages/site/src/components/WhatItCatches.astro
@@ -87,9 +87,9 @@ data-model.md    →  architecture.md`,
       </div>
     </div>
 
-    <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-px border border-ink" style="background: var(--color-ink);">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-px border border-ink" style="background: var(--color-ink);">
       {cards.map(card => (
-        <article class="bg-paper p-6 md:p-7 flex flex-col">
+        <article class="bg-paper p-6 md:p-7 flex flex-col min-w-0">
           <header class="flex items-baseline justify-between gap-4 pb-3 border-b border-rule">
             <span class="font-mono text-[0.72rem] text-accent">[{card.id}]</span>
             <span class="font-mono text-[0.65rem] text-mute uppercase tracking-widest">{card.category}</span>


### PR DESCRIPTION
## Summary
- Previous fix (PR #114) added \`min-w-0\` to \`md:col-span-9\` — but \`md:\` prefix doesn't apply on mobile, so it was a no-op there
- Real fix: WhatItCatches / QuickStart / Integrations grids need explicit \`grid-cols-1\` so mobile uses \`minmax(0, 1fr)\` (instead of content-sized columns)
- Also add \`min-w-0\` to grid items as defense in depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)