### PR TITLE
feat: add contextlint-fix Agent Skill

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -661,6 +661,22 @@ CI パイプラインに追加して、SKILL.md をドキュメントと同期�
 - run: npx contextlint compile --dry-run
 ```
 
+## Agent Skills
+
+contextlint は [Agent Skills](https://agentskills.io) を提供しています。Claude Code、Cursor、Codex、Gemini CLI、GitHub Copilot など、互換性のある任意の AI エージェントから、構造化 Markdown への操作を呼び出せます。
+
+| Skill | 用途 |
+| --- | --- |
+| `contextlint-fix` | contextlint を実行し、検出された違反を自動修正 |
+
+GitHub CLI (v2.90+) でインストール:
+
+```sh
+gh skill install nozomi-koborinai/contextlint contextlint-fix
+```
+
+対応クライアントの全リストは [Agent Skills 標準](https://agentskills.io) を参照してください。
+
 ## パッケージ構成
 
 | パッケージ | 説明 |

--- a/README.ko.md
+++ b/README.ko.md
@@ -640,6 +640,22 @@ CI 파이프라인에 추가하여 SKILL.md를 문서와 동기화합니다:
 - run: npx contextlint compile --dry-run
 ```
 
+## Agent Skills
+
+contextlint는 [Agent Skills](https://agentskills.io)를 제공합니다. Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot 등 호환되는 모든 AI 에이전트에서 구조화된 Markdown 작업에 사용할 수 있습니다.
+
+| Skill | 용도 |
+| --- | --- |
+| `contextlint-fix` | contextlint를 실행하여 감지된 위반 사항을 자동 수정 |
+
+GitHub CLI (v2.90+)로 설치:
+
+```sh
+gh skill install nozomi-koborinai/contextlint contextlint-fix
+```
+
+전체 클라이언트 목록은 [Agent Skills 표준](https://agentskills.io)을 참조하세요.
+
 ## 패키지 구성
 
 | 패키지 | 설명 |

--- a/README.md
+++ b/README.md
@@ -655,6 +655,22 @@ Add to your CI pipeline to keep SKILL.md in sync with documentation:
 - run: npx contextlint compile --dry-run
 ```
 
+## Agent Skills
+
+contextlint ships [Agent Skills](https://agentskills.io) that any compatible AI agent (Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, and more) can use to interact with your structured Markdown.
+
+| Skill | Purpose |
+| --- | --- |
+| `contextlint-fix` | Run contextlint and auto-fix detected violations |
+
+Install with the GitHub CLI (v2.90+):
+
+```sh
+gh skill install nozomi-koborinai/contextlint contextlint-fix
+```
+
+See the [Agent Skills standard](https://agentskills.io) for the full client list.
+
 ## Packages
 
 | Package | Description |

--- a/README.zh.md
+++ b/README.zh.md
@@ -623,6 +623,22 @@ contextlint compile --outdir .claude/skills/my-skill
 - run: npx contextlint compile --dry-run
 ```
 
+## Agent Skills
+
+contextlint 提供 [Agent Skills](https://agentskills.io)，让任何兼容的 AI 代理（Claude Code、Cursor、Codex、Gemini CLI、GitHub Copilot 等）能够操作您的结构化 Markdown。
+
+| Skill | 用途 |
+| --- | --- |
+| `contextlint-fix` | 运行 contextlint 并自动修复检测到的违规 |
+
+通过 GitHub CLI (v2.90+) 安装：
+
+```sh
+gh skill install nozomi-koborinai/contextlint contextlint-fix
+```
+
+完整的客户端列表请参考 [Agent Skills 标准](https://agentskills.io)。
+
 ## 包结构
 
 | 包名 | 说明 |

--- a/skills/contextlint-fix/SKILL.md
+++ b/skills/contextlint-fix/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: contextlint-fix
+description: Run contextlint over the project's structured Markdown and fix the violations it detects. Use when the user asks to fix lint errors, clean up docs, or after running contextlint reveals issues. Handles broken cross-references, missing required sections, empty table cells, leftover placeholders, and circular dependency references across the documentation graph.
+license: MIT
+compatibility: Requires the @contextlint/cli npm package available in the project (will be invoked via npx). Network access only needed if installing the CLI.
+metadata:
+  homepage: https://contextlint.dev
+  source: https://github.com/nozomi-koborinai/contextlint
+---
+
+# contextlint-fix
+
+Run [contextlint](https://contextlint.dev) over the project's structured Markdown and apply fixes for the violations it detects.
+
+## When to use this skill
+
+- User asks to "fix lint errors", "clean up docs", "run contextlint"
+- After bulk changes to Markdown files (e.g., AI-generated specs/ADRs)
+- Before committing changes that touch docs/specs
+
+## Steps
+
+1. **Verify contextlint is set up**:
+   - Check for `contextlint.config.json` in the repo root or any parent dir
+   - Check that `@contextlint/cli` is available (`devDependencies` or `npx`)
+   - If not set up, suggest the `contextlint-init` skill first
+
+2. **Run lint**:
+   ```sh
+   npx contextlint
+   ```
+
+3. **Parse output**. For each violation, apply the strategy below:
+
+   | Rule prefix | Fix strategy |
+   |---|---|
+   | `REF-*` | Broken cross-reference. If the target ID is a typo, fix it. If it genuinely doesn't exist, **ask the user** before deleting the reference. |
+   | `SEC-*` | Missing required section. Add the heading at the appropriate position with `<!-- TODO: fill in -->` placeholder body. |
+   | `TBL-*` | Table issues. Empty cells: insert `TODO`. Allowed-value violations: never invent — ask the user. |
+   | `STR-*` | Missing required file. Create file with minimal placeholder + `<!-- TODO -->`. |
+   | `CHK-*` | Incomplete checklist. Do not silently check items. Report to the user. |
+   | `CTX-*` | Placeholder still present. Flag for user attention — placeholders signal unfinished work. |
+   | `GRP-*` | Graph issue (circular ref, orphan, etc.). Detect the cycle/orphan and propose a fix. **Ask the user before mutating** — graph changes have wide impact. |
+
+4. **Re-run lint** to confirm zero violations.
+
+5. **Summarize** what was auto-fixed and what still needs human input.
+
+## Examples
+
+**User:** "contextlint がエラー出してるから直して"
+
+→ Run `npx contextlint`, parse output, fix mechanical issues (typos in cross-refs, missing required sections via TODO scaffolds), and leave a summary of remaining items needing user input.
+
+## Edge cases
+
+- **No contextlint installed**: suggest `npm install -D @contextlint/cli` or recommend the `contextlint-init` skill
+- **Cross-file rules silently produce nothing**: ensure config's `include` field covers all files referenced by cross-refs
+- **Conflicting fix strategies**: do not silently choose, ask the user
+
+## See also
+
+- Project: https://contextlint.dev
+- Source / issues: https://github.com/nozomi-koborinai/contextlint


### PR DESCRIPTION
## Summary
- New `skills/contextlint-fix/SKILL.md` following the [agentskills.io](https://agentskills.io) specification
- Install: `gh skill install nozomi-koborinai/contextlint contextlint-fix` (GitHub CLI v2.90+)
- Works with any compatible AI agent — Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, etc.
- Auto-fixes mechanical violations; asks the user before mutating semantic content (REF target missing, allowed-value violations, GRP cycles)
- README updated in 4 languages (en/ja/zh/ko) with an Agent Skills section

🤖 Generated with [Claude Code](https://claude.com/claude-code)