### PR TITLE
feat: add contextlint-init and contextlint-impact skills, polish fix

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,23 @@
+{
+  // Reuse the rule config from .markdownlint.jsonc
+  "config": {
+    "extends": ".markdownlint.jsonc"
+  },
+  // Files / directories to skip when linting.
+  // SKILL.md files follow the agentskills.io specification (which permits
+  // longer descriptions, bare URLs, and compact table style) — applying
+  // human-viewer Markdown rules to them produces noise without value.
+  "ignores": [
+    "node_modules/**",
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/.astro/**",
+    "**/.next/**",
+    "skills/**/*.md",
+    "tests/**/*.md",
+    "**/fixtures/**/*.md",
+    "CLAUDE.md",
+    ".claude/**/*.md",
+    ".github/**/*.md"
+  ]
+}

--- a/README.ja.md
+++ b/README.ja.md
@@ -668,6 +668,8 @@ contextlint は [Agent Skills](https://agentskills.io) を提供しています�
 | Skill | 用途 |
 | --- | --- |
 | `contextlint-fix` | contextlint を実行し、検出された違反を自動修正 |
+| `contextlint-init` | repo に contextlint をセットアップ（doc 構造を scan、ルール推論、CLI install） |
+| `contextlint-impact` | Context Graph で doc の変更 / 削除の影響範囲を分析 |
 
 GitHub CLI (v2.90+) でインストール:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -647,6 +647,8 @@ contextlint는 [Agent Skills](https://agentskills.io)를 제공합니다. Claude
 | Skill | 용도 |
 | --- | --- |
 | `contextlint-fix` | contextlint를 실행하여 감지된 위반 사항을 자동 수정 |
+| `contextlint-init` | repo에 contextlint 부트스트랩 (레이아웃 스캔, 규칙 추론, CLI 설치) |
+| `contextlint-impact` | Context Graph로 문서 변경 / 삭제의 영향 분석 |
 
 GitHub CLI (v2.90+)로 설치:
 

--- a/README.md
+++ b/README.md
@@ -662,6 +662,8 @@ contextlint ships [Agent Skills](https://agentskills.io) that any compatible AI 
 | Skill | Purpose |
 | --- | --- |
 | `contextlint-fix` | Run contextlint and auto-fix detected violations |
+| `contextlint-init` | Bootstrap contextlint into a repo (detects layout, infers rules, installs CLI) |
+| `contextlint-impact` | Analyze the impact of changing or deleting a doc using the Context Graph |
 
 Install with the GitHub CLI (v2.90+):
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -630,6 +630,8 @@ contextlint 提供 [Agent Skills](https://agentskills.io)，让任何兼容的 A
 | Skill | 用途 |
 | --- | --- |
 | `contextlint-fix` | 运行 contextlint 并自动修复检测到的违规 |
+| `contextlint-init` | 将 contextlint 引导到仓库（扫描布局、推断规则、安装 CLI） |
+| `contextlint-impact` | 使用 Context Graph 分析更改或删除文档的影响 |
 
 通过 GitHub CLI (v2.90+) 安装：
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,7 +1,8 @@
 # @contextlint/cli
 
-CLI for [contextlint](https://github.com/nozomi-koborinai/contextlint) —
-a rule-based linter for structured Markdown documents.
+CLI for [contextlint](https://contextlint.dev) — a semantic linter for structured Markdown documents.
+
+Catches broken cross-references, missing required sections, empty table cells, leftover placeholders, circular dependency references, and other doc-integrity issues that grep alone can't see.
 
 ## Installation
 
@@ -12,20 +13,27 @@ npm install -D @contextlint/cli
 ## Usage
 
 ```bash
-npx contextlint
+npx contextlint                       # Lint files matched by config
+npx contextlint "docs/**/*.md"        # Override include via CLI args
+npx contextlint --config path/to/config.json
+npx contextlint --format json         # Machine-readable output (CI / editors)
 ```
 
-contextlint auto-detects `contextlint.config.json` from the current
-or any parent directory. You can also specify a config path explicitly:
+## Subcommands
+
+| Command | Purpose |
+| --- | --- |
+| `contextlint` | Lint structured Markdown documents (default) |
+| `contextlint init` | Generate `contextlint.config.json` interactively |
+| `contextlint impact <file>` | Analyze the impact of changing a document |
+| `contextlint slice <query>` | Extract the minimal set of related documents |
+| `contextlint graph` | Show the document dependency graph |
+| `contextlint compile` | Compile docs + config into a `SKILL.md` for AI agents |
+
+## Watch mode
 
 ```bash
-npx contextlint --config path/to/contextlint.config.json
-```
-
-File patterns can be passed as arguments to override the `include` field:
-
-```bash
-npx contextlint "docs/**/*.md"
+npx contextlint --watch     # Re-lint on file changes
 ```
 
 ## Configuration
@@ -37,21 +45,24 @@ Create `contextlint.config.json`:
   "$schema": "https://raw.githubusercontent.com/nozomi-koborinai/contextlint/main/schema.json",
   "include": ["docs/**/*.md"],
   "rules": [
-    { "rule": "tbl001", "options": { "requiredColumns": ["ID", "Status"] } },
-    { "rule": "tbl002", "options": { "columns": ["ID", "Status"] } },
-    { "rule": "ref001" }
+    { "rule": "ref001" },
+    { "rule": "sec001", "options": { "sections": ["Context", "Decision", "Consequences"] } },
+    { "rule": "grp002" }
   ]
 }
 ```
 
-Adding `$schema` enables autocomplete in VS Code, Cursor,
-JetBrains, and other editors. The `include` field defines default
-file patterns; CLI arguments override it. When neither is set,
-`**/*.md` is used.
+`$schema` enables autocomplete in VS Code, Cursor, and JetBrains. `include` defines default file patterns (CLI args override). When neither is set, `**/*.md` is used.
 
-See the
-[main repository](https://github.com/nozomi-koborinai/contextlint)
-for the full list of rules and configuration options.
+See the [main repository](https://github.com/nozomi-koborinai/contextlint) for the full list of rules and configuration options.
+
+## See also
+
+- Project: https://contextlint.dev
+- Agent Skills: `gh skill install nozomi-koborinai/contextlint contextlint-fix` (also `contextlint-init`, `contextlint-impact`)
+- VS Code / Cursor extension: `contextlint-vscode`
+- MCP server: `@contextlint/mcp-server`
+- LSP server (other editors): `@contextlint/lsp-server`
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -58,7 +58,7 @@ See the [main repository](https://github.com/nozomi-koborinai/contextlint) for t
 
 ## See also
 
-- Project: https://contextlint.dev
+- Project: <https://contextlint.dev>
 - Agent Skills: `gh skill install nozomi-koborinai/contextlint contextlint-fix` (also `contextlint-init`, `contextlint-impact`)
 - VS Code / Cursor extension: `contextlint-vscode`
 - MCP server: `@contextlint/mcp-server`

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,6 @@
 # @contextlint/core
 
-Rule engine and Markdown parser for
-[contextlint](https://github.com/nozomi-koborinai/contextlint) —
-a rule-based linter for structured Markdown documents.
+Rule engine, Markdown parser, and Context Graph API for [contextlint](https://contextlint.dev) — a semantic linter for structured Markdown documents.
 
 ## Installation
 
@@ -10,11 +8,9 @@ a rule-based linter for structured Markdown documents.
 npm install @contextlint/core
 ```
 
-> Most users should install
-> [`@contextlint/cli`](https://www.npmjs.com/package/@contextlint/cli)
-> instead. This package is for programmatic usage.
+> Most users should install [`@contextlint/cli`](https://www.npmjs.com/package/@contextlint/cli) instead. This package is for programmatic / library usage.
 
-## Usage
+## Lint usage
 
 ```typescript
 import { parseDocument, runRules, tbl001 } from "@contextlint/core";
@@ -26,15 +22,57 @@ const rule = tbl001({
   requiredColumns: ["ID", "Status", "Description"],
 });
 const messages = runRules([rule], doc, "example.md");
-
-console.log(messages);
 // [{ ruleId: "TBL-001", severity: "error",
 //    message: "Missing required column ...", line: 1 }]
 ```
 
-See the
-[main repository](https://github.com/nozomi-koborinai/contextlint)
-for the full list of rules and configuration options.
+## Context Graph API
+
+Build a dependency graph from parsed documents and analyze cross-doc impact, slice the relevant context for a query, classify impact direct vs transitive, and more.
+
+```typescript
+import {
+  parseDocument,
+  buildContextGraph,
+  getImpactSet,
+} from "@contextlint/core";
+import { readFileSync } from "node:fs";
+
+const documents = new Map();
+documents.set("docs/requirements.md", parseDocument(readFileSync("docs/requirements.md", "utf-8")));
+documents.set("docs/design.md", parseDocument(readFileSync("docs/design.md", "utf-8")));
+
+const graph = buildContextGraph(documents);
+const impacted = getImpactSet(graph, "docs/requirements.md");
+// Set of files affected by changing requirements.md
+```
+
+| Function | Purpose |
+| --- | --- |
+| `buildContextGraph(documents)` | Build a dependency graph from parsed documents |
+| `getImpactSet(graph, filePath)` | All files affected by changing the given file |
+| `getContextSlice(graph, documents, query, maxDepth?)` | Minimal relevant file set for a query (file path or ID) |
+| `topologicalSort(graph)` | Topological order of the document graph |
+| `getComponents(graph)` | Connected components (clusters of related files) |
+| `classifyImpact(graph, filePath)` | Direct vs transitive impact classification |
+| `formatContextGraphSummary(graph)` | Human-readable summary of the graph |
+
+## Compile
+
+`compileContext` synthesizes documents + config into a single `SKILL.md` for downstream AI agents:
+
+```typescript
+import { compileContext } from "@contextlint/core";
+
+const skillMd = await compileContext(["docs/**/*.md"], config, process.cwd());
+```
+
+See the [main repository](https://github.com/nozomi-koborinai/contextlint) for the full rule reference.
+
+## See also
+
+- Project: https://contextlint.dev
+- CLI: `@contextlint/cli`
 
 ## License
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -71,7 +71,7 @@ See the [main repository](https://github.com/nozomi-koborinai/contextlint) for t
 
 ## See also
 
-- Project: https://contextlint.dev
+- Project: <https://contextlint.dev>
 - CLI: `@contextlint/cli`
 
 ## License

--- a/packages/lsp-server/README.md
+++ b/packages/lsp-server/README.md
@@ -1,0 +1,33 @@
+# @contextlint/lsp-server
+
+[Language Server Protocol](https://microsoft.github.io/language-server-protocol/) implementation for [contextlint](https://contextlint.dev) — a semantic linter for structured Markdown documents.
+
+Powers in-editor diagnostics, hover info, and Quick Fixes for VS Code, Cursor, Neovim, Helix, JetBrains IDEs, and any LSP-compatible client.
+
+## Installation
+
+```bash
+npm install -D @contextlint/lsp-server
+```
+
+## Editor setup
+
+Most users get the LSP through the [`contextlint-vscode`](https://github.com/nozomi-koborinai/contextlint/tree/main/packages/vscode) extension (VS Code / Cursor) without installing this server directly.
+
+For other editors, configure your LSP client to spawn `contextlint-lsp` (the binary this package installs) when editing Markdown files in a project that contains `contextlint.config.json`. See the [main repository](https://github.com/nozomi-koborinai/contextlint#lsp-server) for editor-specific setup snippets (Neovim, Helix, JetBrains).
+
+## Features
+
+- Real-time diagnostics for all 21 contextlint rules
+- Hover info showing rule ID and message
+- Quick Fixes for `CHK-001` (incomplete checklist) and `TBL-002` (empty cell)
+- Workspace-wide cross-file rule detection (project-scope rules)
+
+## See also
+
+- Project: https://contextlint.dev
+- VS Code / Cursor extension: `contextlint-vscode`
+
+## License
+
+[MIT](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)

--- a/packages/lsp-server/README.md
+++ b/packages/lsp-server/README.md
@@ -14,7 +14,11 @@ npm install -D @contextlint/lsp-server
 
 Most users get the LSP through the [`contextlint-vscode`](https://github.com/nozomi-koborinai/contextlint/tree/main/packages/vscode) extension (VS Code / Cursor) without installing this server directly.
 
-For other editors, configure your LSP client to spawn `contextlint-lsp` (the binary this package installs) when editing Markdown files in a project that contains `contextlint.config.json`. See the [main repository](https://github.com/nozomi-koborinai/contextlint#lsp-server) for editor-specific setup snippets (Neovim, Helix, JetBrains).
+For other editors, configure your LSP client to spawn `contextlint-lsp`
+(the binary this package installs) when editing Markdown files in a project
+that contains `contextlint.config.json`. See the
+[main repository](https://github.com/nozomi-koborinai/contextlint#lsp-server)
+for editor-specific setup snippets (Neovim, Helix, JetBrains).
 
 ## Features
 
@@ -25,7 +29,7 @@ For other editors, configure your LSP client to spawn `contextlint-lsp` (the bin
 
 ## See also
 
-- Project: https://contextlint.dev
+- Project: <https://contextlint.dev>
 - VS Code / Cursor extension: `contextlint-vscode`
 
 ## License

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -39,7 +39,7 @@ For Claude Desktop on macOS, the config lives at `~/Library/Application Support/
 
 ## See also
 
-- Project: https://contextlint.dev
+- Project: <https://contextlint.dev>
 - CLI: `@contextlint/cli`
 - Agent Skills (alternative for AI integration): `gh skill install nozomi-koborinai/contextlint contextlint-fix` (also `contextlint-init`, `contextlint-impact`)
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,11 +1,8 @@
 # @contextlint/mcp-server
 
-[MCP](https://modelcontextprotocol.io/) server for
-[contextlint](https://github.com/nozomi-koborinai/contextlint) —
-a rule-based linter for structured Markdown documents.
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for [contextlint](https://contextlint.dev) — a semantic linter for structured Markdown documents.
 
-Allows AI tools like Claude and Cursor to lint Markdown
-documents during a conversation.
+Lets AI agents (Claude Code, Cursor Agent, Cline, Windsurf, and others) lint, analyze, and verify Markdown documents during a conversation.
 
 ## Installation
 
@@ -15,8 +12,7 @@ npm install -D @contextlint/mcp-server
 
 ## Setup
 
-Add to your `mcp.json`
-(e.g. `.cursor/mcp.json` or `claude_desktop_config.json`):
+Add to your MCP host config (e.g. `.cursor/mcp.json`, `claude_desktop_config.json`, or your editor's MCP settings):
 
 ```json
 {
@@ -29,16 +25,23 @@ Add to your `mcp.json`
 }
 ```
 
+For Claude Desktop on macOS, the config lives at `~/Library/Application Support/Claude/claude_desktop_config.json`.
+
 ## Available tools
 
-| Tool | Description |
-| ---- | ----------- |
+| Tool | Purpose |
+| --- | --- |
 | `lint` | Lint Markdown content directly with specified rules |
 | `lint-files` | Lint files matching glob patterns using a config file |
+| `context-graph` | Build and return the document dependency graph |
+| `context-slice` | Extract the minimal set of documents relevant to a query |
+| `impact-analysis` | Analyze which documents are affected by changes to a file |
 
-See the
-[main repository](https://github.com/nozomi-koborinai/contextlint)
-for the full list of rules and configuration options.
+## See also
+
+- Project: https://contextlint.dev
+- CLI: `@contextlint/cli`
+- Agent Skills (alternative for AI integration): `gh skill install nozomi-koborinai/contextlint contextlint-fix` (also `contextlint-init`, `contextlint-impact`)
 
 ## License
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,19 +1,18 @@
 # contextlint for VS Code and Cursor
 
-In-editor diagnostics for structured Markdown documents powered by
-`@contextlint/lsp-server`.
+In-editor diagnostics, hover info, and Quick Fixes for structured Markdown documents — powered by [contextlint](https://contextlint.dev) and `@contextlint/lsp-server`.
+
+Works with VS Code, Cursor, Windsurf, VSCodium, and any IDE that runs VS Code extensions.
 
 ## Install from VSIX
 
-Download `contextlint-vscode-*.vsix` from the GitHub Release for the
-version you want to use, then install it manually.
+Download `contextlint-vscode-*.vsix` from the [GitHub Releases](https://github.com/nozomi-koborinai/contextlint/releases) for the version you want, then install it manually.
 
 In VS Code or Cursor:
 
 1. Open the Extensions view.
-2. Select **Views and More Actions...**.
-3. Select **Install from VSIX...**.
-4. Choose the downloaded `.vsix` file.
+2. Select **Views and More Actions...** → **Install from VSIX...**.
+3. Choose the downloaded `.vsix` file.
 
 From the command line:
 
@@ -21,6 +20,17 @@ From the command line:
 code --install-extension contextlint-vscode-VERSION.vsix
 ```
 
-After installation, open a workspace containing `contextlint.config.json`
-and edit a Markdown file. Diagnostics, hover info, and supported Quick
-Fixes will be provided through the contextlint language server.
+After installation, open a workspace containing `contextlint.config.json` and edit a Markdown file. Diagnostics for all 21 rules, hover info, and supported Quick Fixes will be provided through the contextlint language server.
+
+## Other editors
+
+For Neovim, Helix, JetBrains IDEs, and other LSP-compatible clients, install [`@contextlint/lsp-server`](https://www.npmjs.com/package/@contextlint/lsp-server) and follow the [editor setup guide](https://github.com/nozomi-koborinai/contextlint#lsp-server) in the main repository.
+
+## See also
+
+- Project: https://contextlint.dev
+- LSP server (other editors): `@contextlint/lsp-server`
+
+## License
+
+[MIT](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -20,15 +20,21 @@ From the command line:
 code --install-extension contextlint-vscode-VERSION.vsix
 ```
 
-After installation, open a workspace containing `contextlint.config.json` and edit a Markdown file. Diagnostics for all 21 rules, hover info, and supported Quick Fixes will be provided through the contextlint language server.
+After installation, open a workspace containing `contextlint.config.json` and
+edit a Markdown file. Diagnostics for all 21 rules, hover info, and supported
+Quick Fixes will be provided through the contextlint language server.
 
 ## Other editors
 
-For Neovim, Helix, JetBrains IDEs, and other LSP-compatible clients, install [`@contextlint/lsp-server`](https://www.npmjs.com/package/@contextlint/lsp-server) and follow the [editor setup guide](https://github.com/nozomi-koborinai/contextlint#lsp-server) in the main repository.
+For Neovim, Helix, JetBrains IDEs, and other LSP-compatible clients,
+install [`@contextlint/lsp-server`](https://www.npmjs.com/package/@contextlint/lsp-server)
+and follow the
+[editor setup guide](https://github.com/nozomi-koborinai/contextlint#lsp-server)
+in the main repository.
 
 ## See also
 
-- Project: https://contextlint.dev
+- Project: <https://contextlint.dev>
 - LSP server (other editors): `@contextlint/lsp-server`
 
 ## License

--- a/skills/contextlint-fix/SKILL.md
+++ b/skills/contextlint-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contextlint-fix
-description: Run contextlint over the project's structured Markdown and fix the violations it detects. Use when the user asks to fix lint errors, clean up docs, or after running contextlint reveals issues. Handles broken cross-references, missing required sections, empty table cells, leftover placeholders, and circular dependency references across the documentation graph.
+description: Run contextlint over the project's structured Markdown and fix the violations it detects. Use this skill whenever the user asks to fix lint errors, clean up docs, repair broken Markdown links, or after bulk edits to documentation (especially AI-generated specs/ADRs) — even if they don't explicitly mention contextlint by name. Handles broken cross-references, missing required sections, empty table cells, leftover placeholders (TODO/TBD), and circular dependency references across the documentation graph. Reach for this any time the user mentions doc integrity, broken refs, or wants their Markdown checked.
 license: MIT
 compatibility: Requires the @contextlint/cli npm package available in the project (will be invoked via npx). Network access only needed if installing the CLI.
 metadata:
@@ -12,53 +12,111 @@ metadata:
 
 Run [contextlint](https://contextlint.dev) over the project's structured Markdown and apply fixes for the violations it detects.
 
+> **Language note**: This skill is used across many languages. Respond to the user in their primary language (the one they're typing in). The English prompts and outputs below are reference templates — translate them at runtime.
+
 ## When to use this skill
 
-- User asks to "fix lint errors", "clean up docs", "run contextlint"
-- After bulk changes to Markdown files (e.g., AI-generated specs/ADRs)
-- Before committing changes that touch docs/specs
+- The user asks to "fix lint errors", "clean up docs", "repair broken Markdown links", "run contextlint"
+- After bulk changes to Markdown files (especially AI-generated specs / ADRs)
+- Before committing changes that touch docs / specs / ADRs
+- Even when the user doesn't name contextlint explicitly — they want the *outcome* (clean, valid docs)
+
+Triggering phrasings appear across many languages. A few illustrative samples:
+
+- English: "fix lint errors", "clean up the broken links in docs", "fix what contextlint is complaining about"
+- Japanese: "contextlint がエラー出してるから直して", "lint 直して", "壊れたリンク直して"
+- Chinese: "修复 markdown 错误", "清理文档"
+- Korean: "lint 오류 고쳐줘", "문서 정리해줘"
+
+## Why this skill exists
+
+Doc rot (broken cross-refs, missing sections, leftover TODOs) accumulates silently. Manual cleanup is tedious and easy to skip. AI agents bulk-editing docs also accumulate violations as a side effect. This skill turns "go fix the lint output" into a one-step request, while being careful to **never silently mutate semantic content** — only mechanical fixes are auto-applied.
 
 ## Steps
 
-1. **Verify contextlint is set up**:
-   - Check for `contextlint.config.json` in the repo root or any parent dir
-   - Check that `@contextlint/cli` is available (`devDependencies` or `npx`)
-   - If not set up, suggest the `contextlint-init` skill first
+### 1. Verify contextlint is set up
 
-2. **Run lint**:
-   ```sh
-   npx contextlint
-   ```
+- Check for `contextlint.config.json` in the repo root or any parent directory
+- Check that `@contextlint/cli` is available (`devDependencies` or `npx`)
+- If not set up, suggest the `contextlint-init` skill first
 
-3. **Parse output**. For each violation, apply the strategy below:
+**Why?** Without a config, contextlint can't run. Without cross-file rules enabled, many fix opportunities won't surface.
 
-   | Rule prefix | Fix strategy |
-   |---|---|
-   | `REF-*` | Broken cross-reference. If the target ID is a typo, fix it. If it genuinely doesn't exist, **ask the user** before deleting the reference. |
-   | `SEC-*` | Missing required section. Add the heading at the appropriate position with `<!-- TODO: fill in -->` placeholder body. |
-   | `TBL-*` | Table issues. Empty cells: insert `TODO`. Allowed-value violations: never invent — ask the user. |
-   | `STR-*` | Missing required file. Create file with minimal placeholder + `<!-- TODO -->`. |
-   | `CHK-*` | Incomplete checklist. Do not silently check items. Report to the user. |
-   | `CTX-*` | Placeholder still present. Flag for user attention — placeholders signal unfinished work. |
-   | `GRP-*` | Graph issue (circular ref, orphan, etc.). Detect the cycle/orphan and propose a fix. **Ask the user before mutating** — graph changes have wide impact. |
+### 2. Run lint
 
-4. **Re-run lint** to confirm zero violations.
+```sh
+npx contextlint
+```
 
-5. **Summarize** what was auto-fixed and what still needs human input.
+For machine-readable parsing in step 3, add `--format json`.
+
+### 3. Parse output and apply fix strategies
+
+For each violation, apply the strategy below:
+
+| Rule prefix | Auto-fix strategy | Why |
+|---|---|---|
+| `REF-*` | If the target ID looks like a typo, fix the typo. If it genuinely doesn't exist, **ask the user** — silently deleting a reference loses intent. | A broken ref might mean the target was renamed (typo, fix it) or genuinely deleted (intent unclear) |
+| `SEC-*` | Add the missing heading at the appropriate position with `<!-- TODO: fill in -->` body | Section structure is mechanical; content fill-in is human work |
+| `TBL-*` | Empty cells: insert `TODO`. Allowed-value violations: **never invent** — ask the user. | A `TODO` flag is honest; inventing values is dishonest |
+| `STR-*` | Missing required file: create with minimal placeholder + `<!-- TODO -->` | Same as SEC — make the structure exist, leave content to the human |
+| `CHK-*` | Incomplete checklist. Do not silently check items. Report to the user. | Auto-checking erases work-tracking signal |
+| `CTX-*` | Placeholder still present. Flag for user attention — placeholders signal unfinished work. | Silently "finishing" a TODO is a lie |
+| `GRP-*` | Graph issue (circular ref, orphan, etc.). Detect the cycle / orphan and propose a fix. **Ask the user before mutating** — graph changes have wide impact. | Cycle resolution can cascade across many files; user needs to choose the cut point |
+
+**Underlying principle**: mechanical fixes (typos, heading insertion, file creation with placeholder) are auto-applied. Semantic decisions (deletion, value invention, checklist progress, graph cuts) are surfaced for the user. The user owns the meaning; the skill owns the boilerplate.
+
+### 4. Re-run lint to confirm
+
+```sh
+npx contextlint
+```
+
+If zero violations remain, done. If the "ask the user" cases are still present, list them clearly.
+
+### 5. Summarize
+
+End with a clear, scannable summary in the user's language. Example template:
+
+```
+Done:
+  ✓ Fixed 3 typo'd cross-refs in design.md
+  ✓ Added missing "Consequences" section in adr/0005.md (TODO placeholder)
+
+Needs your attention:
+  ? FR-101 referenced in design.md but not defined anywhere — delete the ref or define the requirement?
+  ? Circular reference between architecture.md and overview.md — which side should be the source of truth?
+
+After your decisions, re-run me to clean up.
+```
 
 ## Examples
 
-**User:** "contextlint がエラー出してるから直して"
+User prompts shown in English first; equivalent phrasings in other languages in italics — both should trigger this skill.
 
-→ Run `npx contextlint`, parse output, fix mechanical issues (typos in cross-refs, missing required sections via TODO scaffolds), and leave a summary of remaining items needing user input.
+### Example 1: Mass AI edit cleanup
+
+**User:** "Fix the lint errors" *(equivalent: "contextlint がエラー出してるから直して", "修复 markdown 错误", "lint 오류 고쳐줘")*
+
+→ Run `npx contextlint`, parse output, fix typos and add scaffolds for missing sections, then summarize what was auto-fixed and what needs user input.
+
+### Example 2: Pre-commit cleanup
+
+**User:** "Clean up docs before I commit" *(equivalent: "コミット前に docs 整理して")*
+
+→ Run lint, apply mechanical fixes, surface anything semantic for user judgment, do not auto-decide.
 
 ## Edge cases
 
 - **No contextlint installed**: suggest `npm install -D @contextlint/cli` or recommend the `contextlint-init` skill
 - **Cross-file rules silently produce nothing**: ensure config's `include` field covers all files referenced by cross-refs
-- **Conflicting fix strategies**: do not silently choose, ask the user
+- **Conflicting fix strategies**: do not silently choose — ask the user
+- **Many violations (50+)**: present a grouped summary instead of fixing all at once. Ask the user "fix all auto-fixable ones, or focus on a subset?"
+- **MCP server attached**: prefer the structured `lint` MCP tool over CLI parsing — same logic, no JSON parse step
 
 ## See also
 
 - Project: https://contextlint.dev
-- Source / issues: https://github.com/nozomi-koborinai/contextlint
+- Sister skills:
+  - `contextlint-init` — set up contextlint from scratch (recommended if not yet configured)
+  - `contextlint-impact` — analyze the cascade impact of editing a particular doc

--- a/skills/contextlint-impact/SKILL.md
+++ b/skills/contextlint-impact/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: contextlint-impact
+description: Analyze the impact of changing or deleting a Markdown document by leveraging contextlint's Context Graph. Use this skill whenever the user asks "what breaks if I change X?", "what depends on this doc?", "is it safe to delete this file?", or wants to plan a refactor / understand cross-doc dependencies — even if they don't mention contextlint by name. Detects direct vs transitive impact, identifies orphan docs, and surfaces hidden dependencies that grep alone can't find. Built on contextlint's deterministic graph engine — same input, same answer.
+license: MIT
+compatibility: Requires the @contextlint/cli npm package available in the project (will be invoked via npx) and a configured contextlint.config.json with cross-file rules (`ref001`, `grp002`) enabled.
+metadata:
+  homepage: https://contextlint.dev
+  source: https://github.com/nozomi-koborinai/contextlint
+---
+
+# contextlint-impact
+
+Analyze the **impact of changing or deleting a Markdown document** using contextlint's Context Graph engine. Tells the user not just which files reference the target directly, but the transitive cascade — and surfaces orphans, hubs, and cycles that grep can't see.
+
+> **Language note**: This skill is used across many languages. Respond to the user in their primary language (the one they're typing in). The English prompts and outputs below are reference templates — translate them to match the user's language at runtime.
+
+## When to use this skill
+
+- The user asks "what breaks if I change X?", "what depends on this doc?", "is it safe to delete this file?", "I want to refactor X, what's the impact?"
+- The user is planning a doc restructure or rename
+- The user is verifying after a change that all dependents were updated
+- The user wants to understand cross-doc dependencies before mass-editing
+- Even when contextlint isn't named explicitly — the user wants the *answer*, not the brand
+
+Triggering phrasings appear across many languages. A few illustrative samples (not exhaustive):
+
+- English: "what breaks if I change design.md?", "is FR-101 safe to delete?", "show me what depends on this doc"
+- Japanese: "design.md 変更したら何壊れる?", "FR-101 削除して大丈夫?", "依存関係知りたい"
+- Chinese: "修改 design.md 会影响什么?", "删除这个文件安全吗?"
+- Korean: "design.md 바꾸면 뭐가 깨져?", "이 파일 삭제해도 돼?"
+
+## Why this skill exists
+
+contextlint has a **Context Graph engine** that other linters don't have. In an AI era where docs get mass-edited (and AI agents themselves modify multiple files at once), tracking the cascade of cross-references becomes critical:
+
+- `grep` shows direct mentions but misses transitive impact
+- Human intuition can't trace transitive dependencies across a 100-file repo
+- AI mass-edits without impact awareness leave broken refs scattered across the doc graph
+
+This skill exposes the graph engine through one simple question: *"what breaks if I touch this?"*
+
+## Steps
+
+### 1. Verify contextlint is set up
+
+Look for `contextlint.config.json` at the repo root or any parent directory.
+
+- **If missing**: stop and recommend the `contextlint-init` skill first. Without a config, cross-file rules don't apply, and the graph will be empty.
+- **If present but `ref001` / `grp002` aren't enabled**: warn the user that impact analysis depends on these rules. Suggest running `contextlint-init` in `add` mode to enable them.
+- **If both present**: continue.
+
+**Why these checks?** Impact analysis reads from the graph that cross-file rules build. Without them, the graph is just a flat file list.
+
+### 2. Identify the target
+
+The user's question typically names a file or an ID. Disambiguate before running anything.
+
+| User input | Target |
+|---|---|
+| "design.md 変えたら..." / "what breaks in design.md" | File: `design.md` |
+| "FR-101 削除して..." / "delete FR-101" | ID `FR-101` → resolve to its containing file first |
+| "API の認証部分を refactor したい" / "I want to refactor the auth" | **Ambiguous** — ask the user "which file?" |
+
+**For ID targets**, first locate the file that defines the ID:
+
+```sh
+grep -rn 'FR-101' . --include='*.md'
+```
+
+Then run impact analysis on the *containing file*. `contextlint impact` operates on files; ID questions reduce to file-level analysis once the home file is identified.
+
+### 3. Run the impact analysis
+
+```sh
+npx contextlint impact <target-file> --format json
+```
+
+`--format json` is critical — the human-readable output is for terminals, but JSON makes parsing reliable across agent implementations.
+
+**MCP alternative**: if a contextlint MCP server is attached to the agent's session, prefer the `impact-analysis` MCP tool over the CLI — it returns structured data without a JSON parse step. Detect this by checking the available tools list at the start of the skill.
+
+### 4. Parse the output
+
+The JSON includes:
+
+- **direct**: files that reference the target via cross-refs
+- **transitive**: files reachable through indirect references (parent of refs)
+- **lint violations in the impact set**: any current violations in the affected files (CLI auto-includes these)
+
+If the output is empty:
+
+- The file may be an **orphan** (no incoming refs) — safe to delete from the doc-graph perspective, but verify outside the graph (code references, build configs, README mentions)
+- The config may not include cross-file rules — verify `ref001` / `grp002` are enabled
+
+### 5. Present structured findings
+
+Present a clean, scannable summary in the user's language. Use a tree or grouped layout, not just a flat list.
+
+Example template (translate at runtime):
+
+```
+Impact analysis for `design.md`:
+
+DIRECT (5 files reference this directly):
+  - requirements.md
+  - overview.md
+  - api/auth.md
+  - api/users.md
+  - testing.md
+
+TRANSITIVE (12 more files affected indirectly):
+  - architecture.md (via overview.md)
+  - migrations/2026-01.md (via api/users.md)
+  - ... [list]
+
+⚠ HIGHLIGHTS:
+  - api/auth.md is itself referenced by 8 files → high cascade risk
+  - Lint violations detected in 3 affected files (run `contextlint-fix` after editing)
+
+RECOMMENDATIONS:
+  - Update direct references first, then verify transitive ones still make sense
+  - Consider splitting the change into smaller PRs if cascade is large
+  - Run docs build / tests after changes to catch missed updates
+```
+
+**Why this shape?** A flat list of 17 files is hard to act on. Grouping by direct/transitive + highlighting hubs gives the user a place to start (direct first), a sense of scope (transitive count), and a risk signal (hub warning).
+
+### 6. Recommend follow-up actions
+
+Tailor the recommendations to what the analysis revealed:
+
+| Observation | Recommendation |
+|---|---|
+| Many transitive impacts (>10) | Suggest splitting the change into smaller PRs to keep review tractable |
+| Target file is a hub (high incoming refs) | Recommend a backwards-compatible change strategy (deprecate-then-remove) |
+| Target file is an orphan | Ask whether it's used outside the doc graph (code, build configs) before deleting |
+| Lint violations in the affected files | Recommend running the `contextlint-fix` skill after the user makes their edit |
+| Cycles detected during analysis | Note the cycle, suggest enabling `grp002` if not already, and recommend resolving the cycle before refactoring |
+
+## Examples
+
+User prompts shown in English first; equivalent phrasings in other languages in italics — both should trigger this skill.
+
+### Example 1: File change impact
+
+**User:** "What breaks if I change `design.md`?" *(equivalent: "design.md 変更したら何壊れる?", "修改 design.md 会影响什么?")*
+
+1. Verify `contextlint.config.json` exists with `ref001` enabled.
+2. Target = `design.md`.
+3. Run `npx contextlint impact design.md --format json`.
+4. Parse: 5 direct refs, 12 transitive refs, 3 lint violations in affected files.
+5. Present summary with direct/transitive lists, hub warning for `api/auth.md`, lint violation count.
+6. Recommend updating direct refs first + running `contextlint-fix` after edits.
+
+### Example 2: ID deletion safety check
+
+**User:** "Is it safe to delete the requirement `FR-101`?" *(equivalent: "FR-101 削除して大丈夫?")*
+
+1. Verify config.
+2. Target = ID `FR-101`. Locate via `grep -rn 'FR-101' . --include='*.md'` → found defined in `requirements.md`, referenced from 3 other files.
+3. Run `npx contextlint impact requirements.md --format json`.
+4. Filter the result for files that reference the specific ID `FR-101` (these will fail with broken-cross-ref errors after deletion).
+5. Present: "Deleting `FR-101` will leave broken refs in `design.md`, `testing.md`, `api/users.md`. Update those first, then delete."
+
+### Example 3: Orphan detection
+
+**User:** "Is this old `legacy.md` still in use?" *(equivalent: "legacy.md 使われてる?")*
+
+1. Verify config.
+2. Target = `legacy.md`.
+3. Run impact analysis.
+4. Output: zero direct, zero transitive — orphan from the doc-graph perspective.
+5. Present: "No Markdown file references `legacy.md`. Note: this only covers cross-refs in your doc graph — check code, README, build configs, and any external links before deleting."
+
+## Edge cases
+
+- **No `contextlint.config.json` found**: stop, recommend `contextlint-init` first. Don't try to run impact without a config.
+- **`ref001` / `grp002` not enabled**: cross-file impact won't surface meaningful results — warn the user and recommend enabling them.
+- **Target file doesn't exist**: stop, ask the user to clarify which file (might be a typo or the file was already deleted).
+- **Target is part of a cycle**: report the cycle and recommend resolving it before relying on impact results — cycles can make transitive impact misleading.
+- **Output is large (100+ files affected)**: present a tree/grouped view instead of a flat list. Optionally suggest the user run `contextlint slice` for a narrower context.
+- **MCP server attached**: prefer the structured `impact-analysis` MCP tool over CLI parsing. Both return equivalent data, but MCP is a tool call (no JSON parse needed).
+- **CLI not installed yet**: tell the user to run `npm install -D @contextlint/cli` first, or recommend the `contextlint-init` skill.
+
+## See also
+
+- Project: https://contextlint.dev
+- Context Graph API: https://github.com/nozomi-koborinai/contextlint#context-graph-api
+- Sister skills:
+  - `contextlint-init` — set up contextlint in the repo (prerequisite when not yet configured)
+  - `contextlint-fix` — auto-fix violations the impact analysis surfaces

--- a/skills/contextlint-init/SKILL.md
+++ b/skills/contextlint-init/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: contextlint-init
+description: Bootstrap contextlint into a repository. Use this skill whenever the user wants to set up, install, initialize, or configure contextlint — even if they only say "lint setup", "doc integrity check", or "set up Markdown linting" without naming contextlint by name. Detects the package manager (bun/npm/pnpm/yarn), scans the repo's actual doc layout (no hardcoded `docs/` assumption), infers a rule set tailored to the project's structure (ADR style, spec style, table-heavy, etc.), installs `@contextlint/cli`, and writes `contextlint.config.json`. Also handles existing contextlint setups and offers optional GitHub Actions workflow + README scaffolding.
+license: MIT
+compatibility: Requires bun, npm, pnpm, or yarn for installing @contextlint/cli. Network access needed to fetch the package from npm.
+metadata:
+  homepage: https://contextlint.dev
+  source: https://github.com/nozomi-koborinai/contextlint
+---
+
+# contextlint-init
+
+Bootstrap [contextlint](https://contextlint.dev) into a repository. The goal: take the user from "no doc lint" to "contextlint running with a sensibly tuned config" **without forcing them to read docs or hand-pick from 21 rules**.
+
+> **Language note**: This skill is used across many languages. Respond to the user in their primary language (the one they're typing in). The English prompts and outputs below are reference templates — translate them to match the user's language at runtime.
+
+## When to use this skill
+
+- The user asks to "set up contextlint", "install contextlint", "init lint", "lint setup", "set up Markdown linting", "doc integrity check", or any equivalent phrasing
+- After cloning or starting a doc-heavy repo (specs, ADRs, requirements, design docs)
+- Even when the user doesn't name contextlint explicitly — they want the *outcome*, not the brand name
+
+Triggering phrasings appear across many languages. A few illustrative samples (not exhaustive):
+
+- English: "set up contextlint", "init markdown lint", "lint my docs"
+- Japanese: "contextlint 入れて", "lint 環境整えて", "ドキュメントの整合性チェック導入したい"
+- Chinese: "设置 contextlint", "添加 markdown 检查"
+- Korean: "contextlint 설정해줘", "마크다운 린트 추가해"
+
+## Why this skill exists
+
+contextlint has 21 rules across 7 categories. Asking the user to read each one and pick is a non-starter — they will close the page. This skill closes that gap by **inspecting the actual repo** and proposing a config tailored to the doc style. The user only confirms or refines.
+
+## Steps
+
+### 1. Detect existing contextlint
+
+Look for `contextlint.config.json` at the repo root or any parent directory.
+
+- **If found**, stop and ask the user (in their language):
+  - `(overwrite)` Re-init from scratch
+  - `(add)` Keep existing config, propose new rules to add based on a fresh doc scan
+  - `(skip)` Do nothing
+- **If not found**, continue.
+
+**Why ask?** Silently re-initializing destroys a tuned config; silently adding rules can trip CI for collaborators. The user owns their config — present options, don't decide for them.
+
+### 2. Detect the package manager
+
+Check lockfiles in priority order:
+
+| Lockfile | Manager | Install command |
+|---|---|---|
+| `bun.lock` or `bun.lockb` | bun | `bun add -D @contextlint/cli` |
+| `pnpm-lock.yaml` | pnpm | `pnpm add -D @contextlint/cli` |
+| `yarn.lock` | yarn | `yarn add -D @contextlint/cli` |
+| `package-lock.json` | npm | `npm install -D @contextlint/cli` |
+| (none) | fallback to npm | `npm install -D @contextlint/cli` |
+
+**Why this order?** A repo migrating package managers may have multiple lockfiles; the most modern one (bun) usually reflects current intent. If the user explicitly mentions a different manager, follow them — they know their workflow.
+
+### 3. Detect doc locations (no hardcoded paths)
+
+Real repos put docs in `documentation/`, `doc/`, `specs/`, `adr/`, `decisions/`, etc. Hardcoding `docs/` misses many legitimate setups.
+
+```sh
+# Glob for all Markdown files, excluding common vendor / build dirs
+find . -name "*.md" \
+  -not -path "*node_modules*" \
+  -not -path "*build*" \
+  -not -path "*dist*" \
+  -not -path "*.git*" \
+  -not -path "*.astro*" \
+  -not -path "*.next*"
+```
+
+Then:
+
+1. Group results by parent directory.
+2. Directories with **3+ Markdown files** are candidate doc clusters.
+3. Boost (= more likely a real doc directory) when the directory name matches: `docs`, `doc`, `documentation`, `specs`, `spec`, `requirements`, `adr`, `decisions`, `architecture`, `notes`.
+4. Root-level meta-docs (`README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`) are noted but **not linted by default** — they're project meta, not the structured content contextlint targets.
+5. **Monorepo**: if doc clusters appear under `packages/*/docs/` or similar, list each one.
+
+Present the detected layout and ask the user to confirm. Example (translate to the user's language at runtime):
+
+```
+I found these doc clusters in your repo:
+  - docs/ (15 .md files)
+  - adr/ (8 .md files)
+  - root: README.md, CONTRIBUTING.md, CHANGELOG.md
+
+Should the contextlint `include` cover these two? You can override
+(add `specs/`, exclude `adr/`, etc.).
+```
+
+### 4. Scan content, infer rules
+
+Read 3–5 sample files from each confirmed doc cluster — **don't blow context** by reading every file. Look for these signals:
+
+| Pattern observed in samples | Suggested rule | Why |
+|---|---|---|
+| `[link](file.md#anchor)` cross-refs | **`ref001`** | Broken links are the most common doc-rot issue |
+| Markdown tables with an `ID` column | **`tbl001`** + **`tbl002`** | Structured tables imply schema expectations |
+| Repeated section heading triplets (e.g., `## Context` / `## Decision` / `## Consequences`) | **`sec001`** with detected `sections` option | Repeated structure = de-facto template |
+| Many checklists (`- [ ]`) | **`chk001`** | Unchecked items often mean unfinished work |
+| Placeholder strings (`TODO`, `TBD`, `<pending>`, `???`) | **`ctx001`** | Placeholders signal docs shipped before completion |
+| Multiple files cross-referencing each other | **`grp002`** | Cross-ref-heavy repos benefit from cycle detection |
+
+**Always-on baseline (regardless of scan):** `ref001` and `grp002`.
+
+- `ref001`: Broken links are universally undesirable, no good reason to skip.
+- `grp002`: Cycle detection is cheap and catches real architectural smells; most repos benefit.
+
+**Important: never invent values.** For `sec001`, only propose a `sections` option if you actually observe consistent triplets in the sampled files. Don't assume the user wants `Context/Decision/Consequences` just because the repo has an `adr/` folder — verify in the content.
+
+### 5. Propose the config
+
+Build a draft `contextlint.config.json` and show it to the user with a one-line rationale per rule.
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/nozomi-koborinai/contextlint/main/schema.json",
+  "include": ["docs/**/*.md", "adr/**/*.md"],
+  "rules": [
+    { "rule": "ref001" },
+    { "rule": "grp002" },
+    { "rule": "sec001", "options": { "sections": ["Context", "Decision", "Consequences"] } },
+    { "rule": "ctx001" }
+  ]
+}
+```
+
+Then explain in the user's language. Example template (translate as needed):
+
+```
+Here's the proposed config:
+
+- ref001: cross-refs are common in your repo, so detect broken links
+- grp002: multiple docs reference each other, so prevent circular dependencies
+- sec001: ADR directory shows Context/Decision/Consequences pattern, so require them
+- ctx001: several TODO / TBD placeholders found, so flag them
+
+Does this look right? Add or remove anything?
+```
+
+**Why per-rule rationale?** A rule the user doesn't understand is a rule they'll silently disable later. Two seconds of "why this rule" buys long-term ownership.
+
+### 6. Install & write
+
+Once the user confirms:
+
+1. Run the install command from step 2 in the repo root.
+2. Write the confirmed config to `contextlint.config.json` at the repo root.
+3. Run `npx contextlint` once to surface current violations — **immediate value beats ceremony**.
+
+### 7. Optional add-ons (ask each, don't auto-do)
+
+**GitHub Actions workflow.** If the repo has `.github/workflows/`, ask (in the user's language):
+
+> Add a GitHub Actions workflow to lint on PR? (will create `.github/workflows/contextlint.yml`)
+
+If yes, write a minimal workflow:
+
+```yaml
+name: contextlint
+on: pull_request
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - run: npx contextlint
+```
+
+**README section.** Ask:
+
+> Add a short contextlint section to the README?
+
+If yes, append a 5–8 line block at an appropriate position (before License, after Quick Start, etc.):
+
+```markdown
+## Documentation linting
+
+This repo uses [contextlint](https://contextlint.dev) to verify Markdown integrity.
+
+Run locally:
+
+\`\`\`sh
+npx contextlint
+\`\`\`
+```
+
+**Why ask separately?** GitHub Actions changes CI behavior for everyone; README edits change the visible project surface. Both deserve explicit consent.
+
+### 8. Summary
+
+End with a clear, scannable summary in the user's language. Example template:
+
+```
+Done:
+  ✓ Installed @contextlint/cli (bun)
+  ✓ Wrote contextlint.config.json (4 rules, 2 include paths)
+  ✓ Added GitHub Actions workflow
+
+Initial lint found 3 violations.
+You can fix them with the `contextlint-fix` skill.
+```
+
+## Examples
+
+User prompts shown in English first; equivalent phrasings in other languages in italics — both should trigger this skill.
+
+### Example 1: Fresh ADR-style repo
+
+**User:** "Set up contextlint" *(equivalent: "contextlint 入れて", "设置 contextlint", "contextlint 설정해줘")*
+
+1. Detect: no existing config; `bun.lock` found; repo has `adr/` (12 files) + `docs/` (5 files).
+2. Sample scan: `adr/` files contain `## Context` / `## Decision` / `## Consequences` heading triplets in 9 of 12 files.
+3. Propose: `ref001`, `grp002`, `sec001` (with detected sections), `ctx001`.
+4. User: "OK"
+5. `bun add -D @contextlint/cli`, write config, run `npx contextlint`, summarize.
+
+### Example 2: Existing contextlint, user wants to expand
+
+**User:** "I want to revisit my contextlint config" *(equivalent: "lint の設定見直したい")*
+
+1. Detect: existing `contextlint.config.json` with `ref001` + `tbl001` only.
+2. Ask: `overwrite` / `add` / `skip`.
+3. User picks `add`. Re-scan repo. Propose `grp002` and `ctx001` based on what's there now (placeholders accumulated, more cross-refs added since initial setup).
+4. User confirms. Merge into existing config (preserve existing rule options).
+
+### Example 3: Monorepo
+
+**User:** "Set up contextlint in my bun monorepo" *(equivalent: "monorepo に contextlint 入れたい")*
+
+1. Detect: bun workspace; doc clusters under `packages/api/docs/`, `packages/web/docs/`, `apps/admin/specs/`.
+2. Propose a single root-level config covering all workspaces:
+
+```json
+{
+  "include": ["packages/*/docs/**/*.md", "apps/*/specs/**/*.md"],
+  "rules": [...]
+}
+```
+
+3. Install `@contextlint/cli` at the workspace root.
+
+## Edge cases
+
+- **No Markdown beyond `README.md`**: tell the user contextlint won't add much value here yet (it shines on cross-file integrity). Suggest revisiting once they have structured docs. Don't force a setup that won't help.
+- **Multiple lockfiles** (e.g., both `package-lock.json` and `bun.lock`): pick the most recently modified, or ask the user. Don't assume.
+- **Existing `contextlint.config.json` in a parent directory** (e.g., monorepo with config at the higher level): respect it, don't write a sibling. Tell the user "config is already set at `<path>`, scoped to this workspace".
+- **Private fork or non-standard install**: the `$schema` URL needs to match the user's actual contextlint source. If you detect a non-standard installation, ask before writing the schema URL.
+- **CI exists but isn't GitHub Actions** (e.g., GitLab CI, CircleCI): skip the GitHub Actions step, mention contextlint runs in any CI via `npx contextlint`, and let the user wire it manually.
+
+## See also
+
+- Project: https://contextlint.dev
+- Full rule reference: https://github.com/nozomi-koborinai/contextlint#rules
+- Sister skills:
+  - `contextlint-fix` — auto-fix violations after init reveals them
+  - `contextlint-impact` — analyze the blast radius of editing a particular doc


### PR DESCRIPTION
## Summary
- New `skills/contextlint-init/SKILL.md` — bootstrap contextlint into a repo (detect, scan, infer, install, write config, optional CI/README)
- New `skills/contextlint-impact/SKILL.md` — analyze impact of changing or deleting a doc via the Context Graph
- Polish `skills/contextlint-fix/SKILL.md` — pushy description, multi-language trigger samples, fix strategy with `Why` column, explicit principle
- README updated in 4 languages (en/ja/zh/ko) with the new skills in the Agent Skills table
- All skills follow the [agentskills.io](https://agentskills.io) standard, work with any compatible AI agent (Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, etc.), and avoid Claude-Code-specific extensions (e.g., `\!command` syntax) to stay vendor-neutral

🤖 Generated with [Claude Code](https://claude.com/claude-code)