### PR TITLE
chore: add LICENSE files and npm metadata fields to packages

### DIFF
--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nozomi Koborinai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,13 @@
   "name": "@contextlint/cli",
   "version": "0.0.0",
   "description": "CLI entry point for contextlint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nozomi-koborinai/contextlint.git",
+    "directory": "packages/cli"
+  },
+  "bugs": "https://github.com/nozomi-koborinai/contextlint/issues",
+  "homepage": "https://contextlint.dev",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nozomi Koborinai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,13 @@
   "name": "@contextlint/core",
   "version": "0.0.0",
   "description": "Rule engine and Markdown table parser for contextlint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nozomi-koborinai/contextlint.git",
+    "directory": "packages/core"
+  },
+  "bugs": "https://github.com/nozomi-koborinai/contextlint/issues",
+  "homepage": "https://contextlint.dev",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/lsp-server/LICENSE
+++ b/packages/lsp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nozomi Koborinai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/lsp-server/package.json
+++ b/packages/lsp-server/package.json
@@ -2,6 +2,13 @@
   "name": "@contextlint/lsp-server",
   "version": "0.0.0",
   "description": "Language Server Protocol implementation for contextlint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nozomi-koborinai/contextlint.git",
+    "directory": "packages/lsp-server"
+  },
+  "bugs": "https://github.com/nozomi-koborinai/contextlint/issues",
+  "homepage": "https://contextlint.dev",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/mcp-server/LICENSE
+++ b/packages/mcp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nozomi Koborinai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -2,6 +2,13 @@
   "name": "@contextlint/mcp-server",
   "version": "0.0.0",
   "description": "MCP server for contextlint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nozomi-koborinai/contextlint.git",
+    "directory": "packages/mcp-server"
+  },
+  "bugs": "https://github.com/nozomi-koborinai/contextlint/issues",
+  "homepage": "https://contextlint.dev",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/vscode/LICENSE
+++ b/packages/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nozomi Koborinai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.0",
   "displayName": "contextlint",
   "description": "In-editor diagnostics for structured Markdown documents",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nozomi-koborinai/contextlint.git",
+    "directory": "packages/vscode"
+  },
+  "bugs": "https://github.com/nozomi-koborinai/contextlint/issues",
+  "homepage": "https://contextlint.dev",
   "private": true,
   "publisher": "contextlint",
   "engines": {


### PR DESCRIPTION
## Summary
- Copy root \`LICENSE\` into each publishable package directory (core, cli, mcp-server, lsp-server, vscode)
- Add \`repository\`, \`bugs\`, \`homepage\` fields to each \`package.json\`
- Resolves the warnings from the v1.0.0 publish workflow (\`LICENSE not found\`, \`repository field missing\`)
- These fields populate the metadata on the npm registry page (repo link, issues link, homepage) — improves discoverability
- Takes effect on the next release (e.g. v1.0.1 or v1.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)