### PR TITLE
docs: add internal documentation (architecture, ADRs, roadmap)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -18,6 +18,7 @@
     "**/fixtures/**/*.md",
     "CLAUDE.md",
     ".claude/**/*.md",
-    ".github/**/*.md"
+    ".github/**/*.md",
+    "docs/**/*.md"
   ]
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,119 @@
+# Architecture
+
+contextlint is a semantic linter for structured Markdown documents in the AI era — designed for repositories where AI agents and humans co-edit specs, ADRs, requirements, and design docs.
+
+This document describes how the codebase is organized, what each package does, and the design choices that shape the project.
+
+## Overview
+
+contextlint validates the **meaning** of Markdown — broken cross-references, missing required sections, empty cells, drift between related docs — not its formatting. markdownlint covers formatting (style, syntax); contextlint covers structure and cross-file integrity. The two are complementary.
+
+The project ships as:
+
+- A **rule engine** with 21 rules across 7 categories
+- A **Context Graph** that captures cross-file dependencies
+- Three integration layers (Editor / AI / CI), each via a standard protocol (LSP / MCP / CLI)
+- An LP at <https://contextlint.dev>
+- An Agent Skills bundle distributed via the agentskills.io standard
+
+## Repository structure
+
+contextlint is a [bun workspace](https://bun.sh/docs/install/workspaces) monorepo. Each package has a clear role and a clear boundary:
+
+```text
+contextlint/
+├── packages/
+│   ├── core/         # Rule engine, parser, Context Graph API
+│   ├── cli/          # `contextlint` command
+│   ├── mcp-server/   # MCP server (5 tools)
+│   ├── lsp-server/   # LSP server (diagnostics, hover, Quick Fixes)
+│   ├── vscode/       # VS Code / Cursor extension (consumes lsp-server)
+│   └── site/         # contextlint.dev landing page (Astro)
+├── skills/           # Agent Skills (agentskills.io standard)
+│   ├── contextlint-fix/
+│   ├── contextlint-init/
+│   └── contextlint-impact/
+├── docs/             # Internal documentation (this directory)
+├── tests/            # Integration tests + fixtures
+└── ...
+```
+
+**Boundaries:**
+
+- `cli`, `mcp-server`, `lsp-server` all import from `core`. They never duplicate the lint pipeline or config-loading logic — those live in `core` (`lint-files.ts`, `config.ts`).
+- `vscode` consumes `lsp-server` via `require.resolve` — the extension is a thin client that spawns the LSP server as a subprocess.
+- `site` is private (not published to npm), built with Astro and hosted on Cloudflare Pages.
+- `skills/` is distributed via `gh skill install` (agentskills.io standard), independent of the npm packages.
+
+## Rule engine (core)
+
+Rules live in `packages/core/src/rules/<rule-id>.ts` and are organized by category prefix:
+
+| Prefix | Category | What it validates |
+| --- | --- | --- |
+| `TBL` | Table | Required columns, empty cells, allowed values, patterns, uniqueness, cross-column constraints |
+| `SEC` | Section | Required heading existence and ordering |
+| `STR` | Structure | Project-level file existence |
+| `REF` | Reference | Links, anchors, cross-file ID traceability, stability consistency, zone dependencies, image references |
+| `CHK` | Checklist | Item completion |
+| `CTX` | Context | Placeholder detection (TODO / TBD), term consistency against a glossary |
+| `GRP` | Graph | Traceability chains, circular references, orphan detection |
+
+Each rule exports a **Zod schema** (`xxxSchema`) as the single source of truth for its options — the registry validates options before calling the factory, so consumers don't need `as` casts.
+
+**Cross-file rules** (REF-\*, GRP-\*, TBL-006) rely on a `context.documents` Map that contains every parsed document in scope. Without it they silently produce no results, so consumers must populate it from the config's `include` patterns.
+
+## Context Graph
+
+The Context Graph (`packages/core/src/context-graph.ts`) is what distinguishes contextlint from a plain Markdown linter. It captures the dependency relationships between documents — who references whom — and exposes that as a programmable API.
+
+Public functions:
+
+| Function | Purpose |
+| --- | --- |
+| `buildContextGraph(documents)` | Build the graph from parsed documents |
+| `getImpactSet(graph, filePath)` | All files affected by changing a file (direct + transitive) |
+| `getContextSlice(graph, documents, query, maxDepth?)` | Minimal relevant file set for a query |
+| `topologicalSort(graph)` | Topological order of the document graph |
+| `getComponents(graph)` | Connected components (clusters) |
+| `classifyImpact(graph, filePath)` | Direct vs transitive impact classification |
+| `formatContextGraphSummary(graph)` | Human-readable graph summary |
+
+These power the `impact`, `slice`, and `graph` CLI subcommands and the `context-graph`, `context-slice`, `impact-analysis` MCP tools.
+
+## Three-Layer feedback
+
+contextlint is designed to plug in at three points in the doc lifecycle, each via an open standard:
+
+| Layer | Protocol | Trigger |
+| --- | --- | --- |
+| **While you write** | LSP | Editor diagnostics on every keystroke (debounced) |
+| **While AI writes** | MCP | AI agent calls contextlint to verify its own output |
+| **Before merge** | CLI | CI gate (`npx contextlint`) on PR |
+
+The **vendor-neutral** stance is deliberate: protocol names (LSP / MCP) are technical details. Public-facing materials (LP, README) lead with **concrete tool names** (VS Code, Cursor, Claude Code, Gemini CLI, GitHub Actions) because that's what users recognize. See `decisions/0002-vendor-neutral-positioning.md` for the reasoning.
+
+## Distribution
+
+Different artifacts ship through different channels:
+
+| Artifact | Channel | Tag-driven? |
+| --- | --- | --- |
+| `@contextlint/core`, `cli`, `mcp-server`, `lsp-server` | npm registry | Yes — `v*` git tag triggers `publish.yml` |
+| `contextlint-vscode` (`.vsix`) | GitHub Releases | Yes — same tag |
+| Agent Skills (`contextlint-fix`, `-init`, `-impact`) | `gh skill install nozomi-koborinai/contextlint <skill>` | Yes — pins to git tag |
+| LP | Cloudflare Pages | No — auto on `main` push (scoped via `packages/site/**` watch path) |
+
+A single `vX.Y.Z` tag drives every channel except the LP, which deploys continuously.
+
+## Related ADRs
+
+For the reasoning behind individual decisions, see `docs/decisions/`. Major decisions documented there include:
+
+- Vendor-neutral positioning (LSP / MCP as technical detail, not marketing)
+- Adopting agentskills.io for skill distribution
+- Evergreen LP / OG image (no hardcoded version / license / count)
+- Monorepo structure with bun workspace
+- Core hosts the lint pipeline; consumers never duplicate
+
+The roadmap (`docs/roadmap.md`) tracks what's next.

--- a/docs/decisions/0001-monorepo-bun-workspace.md
+++ b/docs/decisions/0001-monorepo-bun-workspace.md
@@ -1,0 +1,34 @@
+# 0001: Monorepo with bun workspace
+
+**Status**: Accepted (initial decision, ongoing)
+
+## Context
+
+contextlint ships multiple deliverables that share a rule engine: a core library, a CLI, an MCP server, an LSP server, a VS Code extension, an LP site, and an Agent Skills bundle. These evolve together — a change in core's `LintMessage` type, for example, ripples to every consumer.
+
+Options considered:
+
+- Multi-repo (one repo per package). Consistent versions and cross-cutting changes become painful.
+- Lerna / Nx / pnpm workspaces. All viable; heavier configuration than bun's built-in workspace.
+- bun workspace. Built-in, fast install, native TypeScript / ESM support.
+
+## Decision
+
+Use bun workspace (`workspaces: ["packages/*"]` in root `package.json`).
+
+- Each package lives under `packages/` with its own `package.json`.
+- Cross-package dependencies use `workspace:*` notation.
+- Root `bun run --filter '*' build` (and `typecheck`, `test`) runs across all packages.
+- A single `vX.Y.Z` git tag drives all npm publishes via `publish.yml`.
+
+## Consequences
+
+- **+** Single source of truth for cross-cutting types (e.g. `LintMessage` lives in core; every consumer imports it).
+- **+** Atomic refactors across packages in one PR.
+- **+** Single install (`bun install` at root) sets up everything.
+- **−** CI / hosting platforms need explicit hints — Cloudflare Pages defaults to `npm` and chokes on `workspace:*`. Resolved by setting `PACKAGE_MANAGER=bun` as an environment variable.
+- **−** Contributors must use bun, not npm / pnpm / yarn. Mitigated by `"packageManager": "bun@x.y.z"` in the root `package.json`.
+
+## Related
+
+- `decisions/0005-core-hosts-pipeline.md` — the no-duplication rule that depends on this monorepo arrangement.

--- a/docs/decisions/0002-vendor-neutral-positioning.md
+++ b/docs/decisions/0002-vendor-neutral-positioning.md
@@ -1,0 +1,39 @@
+# 0002: Vendor-neutral positioning (LSP / MCP as technical detail)
+
+**Status**: Accepted
+
+## Context
+
+contextlint integrates with editors (via LSP) and AI agents (via MCP). The natural temptation is to lead public messaging with the protocol names ("we ship an LSP server!", "we have an MCP server!"). But:
+
+- Most users don't know what "MCP" or "LSP" mean. They know the *tools they use* — VS Code, Cursor, Neovim, Claude Code, Cline, Windsurf.
+- The MCP-server-as-headline phase has commoditized — "we built an MCP server" no longer drives engagement (per ecosystem read in 2026-05).
+- Protocol-name-as-headline assumes background knowledge the broader audience doesn't have.
+
+## Decision
+
+In all public-facing materials (LP, README, blog posts, social), lead with **concrete tool names**. Demote LSP / MCP to "How it works" / Integrations / FAQ sections.
+
+Example pattern, used in the LP's 3-Layer feedback section:
+
+```text
+While AI writes → AI agent integration
+                  Claude Code · Cursor Agent · Cline · Windsurf
+```
+
+Not:
+
+```text
+MCP integration
+```
+
+## Consequences
+
+- **+** Readers who know the tools (most readers) immediately recognize what contextlint plugs into.
+- **+** Readers who don't care about protocols still understand the value.
+- **+** Future-proof: if a successor protocol to MCP emerges, surface the tools, not the protocol.
+- **−** Loses appeal to MCP-protocol enthusiasts who scan for protocol mentions. They find it in the README / docs anyway, so the loss is small.
+
+## Related
+
+- `decisions/0003-agentskills-io-distribution.md` — same vendor-neutral logic applied to skill distribution.

--- a/docs/decisions/0003-agentskills-io-distribution.md
+++ b/docs/decisions/0003-agentskills-io-distribution.md
@@ -1,0 +1,32 @@
+# 0003: Adopt agentskills.io for skill distribution
+
+**Status**: Accepted
+
+## Context
+
+Agent Skills can be distributed several ways:
+
+- **Claude Code-specific plugin marketplace** (`.claude-plugin/marketplace.json`). Works with Claude Code, but not with Cursor, Codex, Gemini CLI, or any of the 35+ other agentskills.io-compatible clients.
+- **Personal marketplace** under the maintainer's blog / repo. Couples the skill's lifecycle to a personal repo and signals "personal hobby project".
+- **agentskills.io standard**. Vendor-neutral open standard originally from Anthropic, adopted by Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, OpenCode, OpenHands, and dozens of others. Distribution via `gh skill install <owner>/<repo> <skill>` (GitHub CLI subcommand v2.90+).
+
+## Decision
+
+Ship Agent Skills under `skills/<skill-name>/SKILL.md` in the contextlint repo, following the agentskills.io specification.
+
+- The contextlint repo itself is the distribution channel. No separate marketplace repo.
+- Users install with `gh skill install nozomi-koborinai/contextlint <skill> [--pin vX.Y.Z]`.
+- Skills coordinate releases with the npm packages: a single `vX.Y.Z` git tag drives both.
+- Avoid Claude-Code-specific syntax inside SKILL.md (e.g., the `` !`command` `` dynamic context injection) so skills stay portable across all agentskills.io clients.
+
+## Consequences
+
+- **+** Skills work in 35+ AI agent clients out of the box.
+- **+** Discoverable via `gh skill search` (GitHub Code Search backend).
+- **+** Same release cadence as the core packages — no separate skill-only releases to manage.
+- **−** Lose Claude-Code-specific niceties (dynamic context injection, namespacing tricks). Mitigated by writing instructions for the AI to execute via Bash, which works everywhere.
+- **−** No central skill registry — discovery relies on GitHub search and external mentions (LP, README, blog).
+
+## Related
+
+- `decisions/0002-vendor-neutral-positioning.md` — same vendor-neutral principle, applied to messaging rather than distribution.

--- a/docs/decisions/0004-evergreen-lp.md
+++ b/docs/decisions/0004-evergreen-lp.md
@@ -1,0 +1,34 @@
+# 0004: Evergreen LP (no hardcoded version / license / count)
+
+**Status**: Accepted
+
+## Context
+
+Public assets that are slow or expensive to update (LP HTML, OG image, social previews) accumulate maintenance debt when they hardcode values that change frequently:
+
+- "**21 rules**" in the hero — rule additions force LP edits.
+- "v0.9 · MIT" in the OG image footer — every release means re-rendering the image and waiting for social-platform image caches to expire (days to weeks).
+- "Rules count: 21" in spec tables — same problem.
+
+These edits aren't hard, but they accumulate friction that discourages frequent releases. Worse, if forgotten, they make the project look stale.
+
+## Decision
+
+Treat every "set-and-forget" public surface as **evergreen**: no hardcoded values that change with releases.
+
+- LP body / hero / CTAs: use generic phrasing ("the full ruleset", "many rules") instead of counts.
+- OG image: brand name + tagline + URL only. No version, no license, no rule count.
+- Footer copyright: derive the year from `new Date().getFullYear()`.
+- README / docs body: counts are fine here (easier to update, version-controlled).
+
+Exceptions:
+
+- Section headings intentionally a snapshot ("Six examples." in the LP's WhatItCatches section — counts what's *on the LP*, not the world).
+- Versioned spec tables (Hero's `[rules] 21` is a v0.x snapshot, refreshed with the release cadence).
+
+## Consequences
+
+- **+** No re-rendering OG images on every release.
+- **+** No social-platform image cache invalidation pain.
+- **+** Friction-free release cadence.
+- **−** Slightly less specific copy ("the full ruleset" vs "21 rules"). Mitigated by linking to the full reference in the README and docs.

--- a/docs/decisions/0005-core-hosts-pipeline.md
+++ b/docs/decisions/0005-core-hosts-pipeline.md
@@ -1,0 +1,42 @@
+# 0005: core hosts the lint pipeline; consumers never duplicate
+
+**Status**: Accepted (enforced)
+
+## Context
+
+Three packages need to lint files: `cli`, `mcp-server`, `lsp-server`. Each could implement its own glob → read → parse → run-rules → format pipeline. Tempting to "just inline it for now". But:
+
+- Bug fixes in the pipeline would need synchronized PRs across three packages.
+- Output formatting (human / JSON) drift between consumers is a UX hazard.
+- Config loading rules (precedence, defaults, walk-up search) are tricky enough to deserve a single owner.
+
+This concern was hit twice during early development:
+
+- Issue #52: `lintFiles` was duplicated between cli and mcp-server.
+- Issue #53: `findConfig` / `loadConfig` were duplicated.
+
+Both were consolidated into core.
+
+## Decision
+
+`@contextlint/core` is the **single source of truth** for:
+
+- The lint pipeline (`lint-files.ts`)
+- Config loading (`config.ts`: `findConfig`, `loadConfig`)
+- Result formatting (`formatFileResults`, `formatContentResults`)
+
+Consumers (`cli`, `mcp-server`, `lsp-server`) import from core and assemble user-facing layers on top. They never re-implement these.
+
+`lintFiles` is intentionally **synchronous** (`globSync` + `readFileSync`). Do not introduce an async variant — that would split the pipeline.
+
+## Consequences
+
+- **+** Single bug-fix surface for the lint pipeline.
+- **+** Consistent output across CLI, MCP, LSP.
+- **+** New consumers (e.g., a future GitHub Action wrapper) start from a vetted base.
+- **−** Anyone touching the pipeline must be aware their change affects every consumer. CI catches breakage but reviewers should still ack the cross-package impact.
+- **−** Synchronous-only constraint may bite if a future consumer needs async (e.g., streaming over a network protocol). Revisit if it actually happens; don't optimize prematurely.
+
+## Related
+
+- CLAUDE.md (the "CLI / MCP parity" section) restates this rule for everyone working in the repo.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,57 @@
+# Roadmap
+
+This is a working roadmap, not a contract. Items here may move, combine, or drop based on what's actually useful and what's not. Dates are intentionally absent — version numbers and the "Recently shipped" section serve as the timeline.
+
+## Recently shipped (v1.0, 2026-05)
+
+- Landing page at <https://contextlint.dev>
+- npm packages: core, cli, mcp-server, lsp-server (all v1.0.x)
+- VS Code / Cursor extension (`.vsix`) attached to GitHub Releases
+- Agent Skills bundle (`contextlint-fix`, `contextlint-init`, `contextlint-impact`) via agentskills.io / `gh skill install`
+- Internal docs (this directory)
+
+## Planned (v1.x)
+
+### Marketplace publishing
+
+Publish `contextlint-vscode` to:
+
+- VS Code Marketplace
+- Open VSX (for VSCodium / Cursor users who pull from there)
+
+Currently shipped only as a VSIX attached to GitHub Releases.
+
+### Starlight product docs
+
+Add product documentation under `contextlint.dev/docs/`:
+
+- Per-rule reference (`/docs/rules/<id>/`)
+- CLI reference, MCP / LSP setup guides
+- Examples and recipes
+
+Built as a `packages/site` extension via Starlight integration; kept evergreen and version-aware.
+
+### Skills validation in CI
+
+Run `skills-ref validate ./skills/*` on PR to catch broken `SKILL.md` frontmatter before tags fly. Low-cost addition to `ci.yml`.
+
+### contextlint dogfooding in CI
+
+Now that `docs/` exists, wire `npx contextlint` into `ci.yml` to lint this very directory on every PR. Catches rot in the project's own internal docs the same way it catches rot in users' repos.
+
+## Under consideration (no commit yet)
+
+- New rule categories driven by user reports (e.g., `IMG-*` for image-related checks).
+- Optional formatter — auto-rewrite for some violations beyond what `contextlint-fix` does today.
+- Richer `contextlint compile` output (more useful SKILL.md for downstream agents).
+
+## Won't do (for now)
+
+- Replicating markdownlint formatting rules. Out of scope; we recommend running both linters.
+- A central skill registry. Relying on agentskills.io / GitHub search instead.
+- A plugin system for custom rules in user repos. The rule-author skill + monkey-patch story isn't compelling enough yet.
+
+## See also
+
+- `docs/architecture.md` for the current system shape.
+- `docs/decisions/` for the reasoning behind major choices.


### PR DESCRIPTION
## Summary
- New \`docs/\` directory: architecture overview, 5 ADRs, roadmap
- Step 1 of the dogfooding plan — gives contextlint something real to lint against itself
- Next: run \`contextlint-init\` skill in this repo, then add \`npx contextlint\` to ci.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)