### PR TITLE
chore: dogfood contextlint on internal docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,5 @@ jobs:
       - run: bunx eslint .
 
       - run: bunx markdownlint-cli2 "README*.md"
+
+      - run: bun run lint:docs

--- a/contextlint.config.json
+++ b/contextlint.config.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "./schema.json",
+  "include": ["docs/**/*.md"],
+  "rules": [
+    { "rule": "ref001" },
+    { "rule": "grp002" },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "decisions/*.md",
+        "sections": ["Context", "Decision", "Consequences"]
+      }
+    },
+    { "rule": "ctx001" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "bun run --filter '*' build",
     "test": "bun test",
     "lint": "eslint .",
+    "lint:docs": "node packages/cli/dist/index.js",
     "typecheck": "bun run --filter '*' typecheck"
   },
   "engines": {


### PR DESCRIPTION
## Summary

- Add `contextlint.config.json` at repo root, scoped to `docs/**/*.md` (excludes test fixtures, package READMEs, project meta)
- Enable `ref001` (broken links), `grp002` (circular refs), `sec001` for `decisions/*.md` (Context/Decision/Consequences template), `ctx001` (placeholders)
- Add `lint:docs` script to root `package.json` (uses workspace `@contextlint/cli` build artifact: `node packages/cli/dist/index.js`)
- Wire `bun run lint:docs` into `ci.yml` — fulfils the **"contextlint dogfooding in CI"** item from `docs/roadmap.md`
- Initial run: **0 violations**. Lint serves as a regression gate for future docs growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)