### PR TITLE
fix(site): PageSpeed fixes and add privacy page

### DIFF
--- a/packages/site/public/robots.txt
+++ b/packages/site/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/packages/site/src/components/Footer.astro
+++ b/packages/site/src/components/Footer.astro
@@ -17,12 +17,13 @@ const year = new Date().getFullYear();
         <nav class="flex flex-col gap-2 text-sm font-mono">
           <a href="https://github.com/nozomi-koborinai/contextlint" class="link-mark">github →</a>
           <a href="https://www.npmjs.com/package/@contextlint/cli" class="link-mark">npm →</a>
+          <a href="/privacy" class="link-mark">privacy →</a>
         </nav>
       </div>
     </div>
     <hr class="mt-12" />
     <div class="flex flex-wrap items-center justify-between gap-3 mt-6 text-xs font-mono text-mute">
-      <span>© {year} contextlint</span>
+      <span>© {year} contextlint · <a href="/privacy" class="link-mark">no cookies, no tracking</a></span>
       <span>Made by <a href="https://koborin.ai" class="link-mark text-ink">Nozomi Koborinai</a></span>
     </div>
   </div>

--- a/packages/site/src/components/Hero.astro
+++ b/packages/site/src/components/Hero.astro
@@ -13,7 +13,7 @@
       <span class="hidden md:inline opacity-60">[REF: README.md]</span>
     </div>
 
-    <h1 class="display-xl mt-10 reveal reveal-2">
+    <h1 class="display-xl mt-10">
       <span class="block">markdownlint</span>
       <span class="block text-mute">for syntax.</span>
       <span class="block mt-3">contextlint</span>
@@ -48,8 +48,10 @@
         </div>
         <div class="border-b border-rule py-4 px-5 md:border-r flex flex-col">
           <dt class="font-mono text-[0.65rem] text-mute uppercase tracking-widest">[protocols]</dt>
-          <dd class="font-display text-2xl md:text-3xl mt-1.5" style="font-weight: 600;">3</dd>
-          <span class="font-mono text-[0.65rem] text-mute mt-1">LSP · MCP · CLI</span>
+          <dd class="font-display text-2xl md:text-3xl mt-1.5" style="font-weight: 600;">
+            3
+            <span class="block font-mono text-[0.65rem] text-mute mt-1" style="font-weight: 400;">LSP · MCP · CLI</span>
+          </dd>
         </div>
         <div class="border-b border-rule py-4 px-5 flex flex-col">
           <dt class="font-mono text-[0.65rem] text-mute uppercase tracking-widest">[latency]</dt>

--- a/packages/site/src/pages/privacy.astro
+++ b/packages/site/src/pages/privacy.astro
@@ -1,0 +1,76 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+---
+
+<Layout
+  title="Privacy — contextlint"
+  description="contextlint.dev uses no cookies and does not track visitors. Cloudflare Web Analytics is cookieless."
+>
+  <Header />
+  <main>
+    <section class="rule-top relative">
+      <div class="container-edit pt-12 pb-20 md:pt-16 md:pb-32">
+
+        <div class="flex items-center justify-between text-[0.7rem] font-mono text-mute">
+          <div class="flex items-center gap-3">
+            <span>§ PRIVACY / 999</span>
+            <span class="opacity-50 hidden sm:inline">———</span>
+            <span class="hidden sm:inline">NO COOKIES · NO TRACKING</span>
+          </div>
+          <span class="hidden md:inline opacity-60">[Updated: 2026-05-05]</span>
+        </div>
+
+        <h1 class="display-xl mt-10">Privacy</h1>
+
+        <p class="body-lead mt-12 max-w-3xl">
+          contextlint.dev does not use cookies and does not track visitors.
+        </p>
+
+        <div class="mt-16 max-w-3xl space-y-12">
+          <div>
+            <div class="sct-numeral mb-3">// analytics</div>
+            <p class="text-[0.95rem] leading-relaxed">
+              We use <a href="https://www.cloudflare.com/web-analytics/" class="link-mark text-ink">Cloudflare Web Analytics</a>,
+              a cookieless analytics service that collects only aggregated,
+              anonymous traffic data (page views, browser types, country-level
+              location). No personal information is collected, and no cookies
+              are set.
+            </p>
+          </div>
+
+          <div>
+            <div class="sct-numeral mb-3">// infrastructure</div>
+            <p class="text-[0.95rem] leading-relaxed">
+              The site is hosted on Cloudflare Pages. Cloudflare may set
+              strictly necessary cookies (e.g., <code class="font-mono text-[0.85rem]">__cf_bm</code> for
+              bot management) at the infrastructure level — these are required
+              for security and content delivery, and are exempt from cookie
+              consent under ePrivacy / GDPR.
+            </p>
+          </div>
+
+          <div>
+            <div class="sct-numeral mb-3">// third parties</div>
+            <p class="text-[0.95rem] leading-relaxed">
+              We do not share, sell, or transfer any visitor data to third
+              parties. The site loads fonts from Google Fonts; no other
+              third-party services are used.
+            </p>
+          </div>
+
+          <div>
+            <div class="sct-numeral mb-3">// contact</div>
+            <p class="text-[0.95rem] leading-relaxed">
+              For questions, open an issue on
+              <a href="https://github.com/nozomi-koborinai/contextlint" class="link-mark text-ink">GitHub</a>.
+            </p>
+          </div>
+        </div>
+
+      </div>
+    </section>
+  </main>
+  <Footer />
+</Layout>

--- a/packages/site/src/pages/privacy.astro
+++ b/packages/site/src/pages/privacy.astro
@@ -36,7 +36,9 @@ import Footer from "../components/Footer.astro";
               a cookieless analytics service that collects only aggregated,
               anonymous traffic data (page views, browser types, country-level
               location). No personal information is collected, and no cookies
-              are set.
+              are set — see Cloudflare's
+              <a href="https://blog.cloudflare.com/privacy-first-web-analytics/" class="link-mark text-ink">Privacy-first Web Analytics</a>
+              post for the technical details.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary

PageSpeed Insights flagged three issues on https://contextlint.dev; this PR resolves them and adds a Privacy page in the same scope (small, related polish).

**PageSpeed fixes:**

- **`robots.txt` (85 errors)**: Cloudflare Pages SPA fallback returned `index.html` for `/robots.txt`, so Lighthouse parsed HTML as robots.txt. Adds `packages/site/public/robots.txt` with `User-agent: * / Allow: /`.
- **LCP NO_LCP**: caused by `.reveal { opacity: 0 }` on the Hero `<h1>`. Lighthouse couldn't detect a paint-eligible LCP candidate. Drops `reveal reveal-2` from `<h1>` so the heading paints immediately; surrounding elements keep their fade-in.
- **`<dl>` accessibility warning**: the `[protocols]` cell had a `<span>` sibling next to `<dt>`/`<dd>`. Moves the `LSP · MCP · CLI` annotation inside `<dd>` as a block-level child. Visual layout preserved.

**Privacy page:**

- Adds `/privacy` documenting that the site uses no cookies and does not track visitors. Covers analytics, infrastructure cookies (`__cf_bm` ePrivacy exemption), third parties (Google Fonts only), and contact
- Adds Privacy link to Footer resources nav
- Adds `// no cookies, no tracking` notice in Footer bottom bar (links to `/privacy`)

**Source for the cookieless claim:**

Cloudflare's official blog post — [Privacy-first Web Analytics](https://blog.cloudflare.com/privacy-first-web-analytics/) — states verbatim:

> "We don't use any client-side state (like cookies or localStorage) for analytics purposes."

> "Cloudflare also doesn't track users over time via their IP address, User Agent string, or any other immutable attributes for the purposes of displaying analytics"

This holds whether Web Analytics is enabled via the Pages dashboard or via manual beacon embedding — both paths use the same cookieless beacon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)