### PR TITLE
feat(rules/REF-001): support routed URL resolution via siteRouter (Starlight)

### DIFF
--- a/contextlint.config.json
+++ b/contextlint.config.json
@@ -1,8 +1,25 @@
 {
   "$schema": "./schema.json",
-  "include": ["docs/**/*.md"],
+  "include": [
+    "docs/**/*.md",
+    "packages/site/src/content/docs/**/*.md"
+  ],
   "rules": [
-    { "rule": "ref001" },
+    {
+      "rule": "ref001",
+      "options": {
+        "siteRouter": {
+          "preset": "starlight",
+          "contentDir": "packages/site/src/content/docs",
+          "defaultLocale": "root",
+          "locales": ["root", "ja", "ko", "zh"]
+        }
+      }
+    },
+    { "rule": "ref005" },
+    { "rule": "ref006" },
+    { "rule": "chk001" },
+    { "rule": "ctx001" },
     { "rule": "grp002" },
     {
       "rule": "sec001",
@@ -11,6 +28,89 @@
         "sections": ["Context", "Decision", "Consequences"]
       }
     },
-    { "rule": "ctx001" }
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "content/docs/docs/rules/*-*.md",
+        "sections": ["Overview", "Why it matters", "Options", "Bad example", "After fix", "Configuration example", "Related rules"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "ja/docs/rules/*-*.md",
+        "sections": ["概要", "なぜ必要か", "オプション", "違反例", "修正後", "設定例", "関連ルール"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "ko/docs/rules/*-*.md",
+        "sections": ["개요", "왜 필요한가", "옵션", "위반 예시", "수정 후", "설정 예시", "관련 규칙"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "zh/docs/rules/*-*.md",
+        "sections": ["概述", "为什么需要", "选项", "违例", "修正后", "配置示例", "相关规则"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "content/docs/docs/graph-api/*-*.md",
+        "sections": ["Overview", "Why it exists", "Signature", "Parameters", "Return value", "Example", "Related functions"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "ja/docs/graph-api/*-*.md",
+        "sections": ["概要", "なぜ必要か", "シグネチャ", "引数", "戻り値", "使用例", "関連関数"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "ko/docs/graph-api/*-*.md",
+        "sections": ["개요", "왜 필요한가", "시그니처", "인수", "반환값", "사용 예시", "관련 함수"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "zh/docs/graph-api/*-*.md",
+        "sections": ["概述", "为什么需要", "签名", "参数", "返回值", "使用示例", "相关函数"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "content/docs/docs/recipes/{adr-style-repo-setup,spec-driven-development-setup,monorepo-setup}.md",
+        "sections": ["Which projects it suits", "Recommended config (contextlint.config.json)", "Why each rule was chosen", "Operational notes"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "ja/docs/recipes/{adr-style-repo-setup,spec-driven-development-setup,monorepo-setup}.md",
+        "sections": ["どんなプロジェクトに向くか", "推奨構成 (contextlint.config.json)", "各ルールを選んだ理由", "運用上の注意点"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "ko/docs/recipes/{adr-style-repo-setup,spec-driven-development-setup,monorepo-setup}.md",
+        "sections": ["어떤 프로젝트에 적합한가", "권장 구성 (contextlint.config.json)", "각 규칙을 선택한 이유", "운영상의 주의점"]
+      }
+    },
+    {
+      "rule": "sec001",
+      "options": {
+        "files": "zh/docs/recipes/{adr-style-repo-setup,spec-driven-development-setup,monorepo-setup}.md",
+        "sections": ["适用于哪类项目", "推荐配置 (contextlint.config.json)", "选择各条规则的理由", "运维上的注意事项"]
+      }
+    }
   ]
 }

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -6,6 +6,7 @@ import type {
   Definition,
   Heading,
   Image,
+  InlineCode,
   Link,
   ListItem,
   Table,
@@ -62,6 +63,9 @@ export interface ParsedDocument {
 function extractText(node: Node): string {
   if (node.type === "text") {
     return (node as Text).value;
+  }
+  if (node.type === "inlineCode") {
+    return (node as InlineCode).value;
   }
   if ("children" in node) {
     return (node as { children: Node[] }).children.map(extractText).join("");

--- a/packages/core/src/rules/ref-001.test.ts
+++ b/packages/core/src/rules/ref-001.test.ts
@@ -173,3 +173,155 @@ describe("REF-001", () => {
     expect(messages[0].message).toContain("需求文档.md");
   });
 });
+
+describe("REF-001 with siteRouter (starlight preset)", () => {
+  const starlightOptions: Ref001Options = {
+    siteRouter: {
+      preset: "starlight",
+      contentDir: "/project/site/docs",
+      defaultLocale: "root",
+      locales: ["root", "ja", "ko", "zh"],
+    },
+  };
+
+  it("resolves root locale URL to <contentDir>/<rest>/index.md", () => {
+    const messages = lint(
+      "/project/site/docs/index.md",
+      {
+        "/project/site/docs/index.md": "[get started](/docs/get-started/)",
+        "/project/site/docs/docs/get-started/index.md": "# Get Started",
+      },
+      starlightOptions,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("resolves ja locale URL to <contentDir>/ja/<rest>/index.md", () => {
+    const messages = lint(
+      "/project/site/docs/ja/index.md",
+      {
+        "/project/site/docs/ja/index.md": "[はじめに](/ja/docs/get-started/)",
+        "/project/site/docs/ja/docs/get-started/index.md": "# はじめに",
+      },
+      starlightOptions,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("resolves ko locale URL to <contentDir>/ko/<rest>/index.md", () => {
+    const messages = lint(
+      "/project/site/docs/ko/index.md",
+      {
+        "/project/site/docs/ko/index.md": "[시작하기](/ko/docs/get-started/)",
+        "/project/site/docs/ko/docs/get-started/index.md": "# 시작하기",
+      },
+      starlightOptions,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("resolves zh locale URL to <contentDir>/zh/<rest>/index.md", () => {
+    const messages = lint(
+      "/project/site/docs/zh/index.md",
+      {
+        "/project/site/docs/zh/index.md": "[入门](/zh/docs/get-started/)",
+        "/project/site/docs/zh/docs/get-started/index.md": "# 入门",
+      },
+      starlightOptions,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("reports broken Starlight URL when target file does not exist", () => {
+    const messages = lint(
+      "/project/site/docs/index.md",
+      {
+        "/project/site/docs/index.md": "[missing](/docs/missing-page/)",
+      },
+      starlightOptions,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain("/docs/missing-page/");
+  });
+
+  it("resolves Starlight URL with .md fallback when no index.md", () => {
+    const messages = lint(
+      "/project/site/docs/index.md",
+      {
+        "/project/site/docs/index.md": "[direct](/docs/single-page/)",
+        "/project/site/docs/docs/single-page.md": "# Single Page",
+      },
+      starlightOptions,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("strips anchor from Starlight URL when checking", () => {
+    const messages = lint(
+      "/project/site/docs/index.md",
+      {
+        "/project/site/docs/index.md": "[heading](/docs/get-started/#section)",
+        "/project/site/docs/docs/get-started/index.md": "# Get Started",
+      },
+      starlightOptions,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("still resolves relative paths when siteRouter is set", () => {
+    const messages = lint(
+      "/project/site/docs/concepts/overview.md",
+      {
+        "/project/site/docs/concepts/overview.md": "[next](./details.md)",
+        "/project/site/docs/concepts/details.md": "# Details",
+      },
+      starlightOptions,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("treats absolute URL as filesystem path when siteRouter is NOT set", () => {
+    // Regression: without siteRouter, /docs/get-started/ is filesystem-resolved
+    // (existing behavior preserved)
+    const messages = lint("/project/site/docs/index.md", {
+      "/project/site/docs/index.md": "[get started](/docs/get-started/)",
+      "/project/site/docs/docs/get-started/index.md": "# Get Started",
+    });
+    expect(messages).toHaveLength(1);
+  });
+});
+
+describe("REF-001 with siteRouter (generic, no preset)", () => {
+  it("resolves URL via urlPrefix + contentDir mapping", () => {
+    const messages = lint(
+      "/project/wiki/index.md",
+      {
+        "/project/wiki/index.md": "[page](/wiki/some-page/)",
+        "/project/wiki/some-page/index.md": "# Some Page",
+      },
+      {
+        siteRouter: {
+          contentDir: "/project/wiki",
+          urlPrefix: "/wiki",
+        },
+      },
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("reports broken URL with generic router", () => {
+    const messages = lint(
+      "/project/wiki/index.md",
+      {
+        "/project/wiki/index.md": "[missing](/wiki/missing/)",
+      },
+      {
+        siteRouter: {
+          contentDir: "/project/wiki",
+          urlPrefix: "/wiki",
+        },
+      },
+    );
+    expect(messages).toHaveLength(1);
+  });
+});

--- a/packages/core/src/rules/ref-001.ts
+++ b/packages/core/src/rules/ref-001.ts
@@ -4,14 +4,82 @@ import { globMatch } from "../utils/glob-match.js";
 import * as z from "zod/v4";
 import type { Rule } from "../rule.js";
 
+const siteRouterSchema = z.object({
+  preset: z.enum(["starlight"]).optional(),
+  contentDir: z.string(),
+  defaultLocale: z.string().optional(),
+  locales: z.array(z.string()).optional(),
+  urlPrefix: z.string().optional(),
+  indexFile: z.string().optional(),
+}).strict();
+
+type SiteRouterOptions = z.infer<typeof siteRouterSchema>;
+
 export const ref001Schema = z.object({
   exclude: z.array(z.string()).optional(),
+  siteRouter: siteRouterSchema.optional(),
 }).strict().optional();
 
 export type Ref001Options = z.infer<typeof ref001Schema>;
 
+function resolveStarlightUrl(url: string, router: SiteRouterOptions): string[] {
+  const contentDir = router.contentDir;
+  const locales = router.locales ?? [];
+  const defaultLocale = router.defaultLocale ?? "root";
+  const indexFile = router.indexFile ?? "index.md";
+
+  const trimmed = url.replace(/\/$/, "").replace(/^\//, "");
+  const parts = trimmed.split("/").filter(Boolean);
+
+  let localeFolder = "";
+  let restParts = parts;
+
+  const firstPart = parts[0];
+  if (
+    firstPart &&
+    locales.includes(firstPart) &&
+    firstPart !== defaultLocale &&
+    firstPart !== "root"
+  ) {
+    localeFolder = firstPart;
+    restParts = parts.slice(1);
+  }
+
+  const basePath = [contentDir, localeFolder, ...restParts]
+    .filter((s): s is string => Boolean(s))
+    .join("/");
+
+  return [`${basePath}/${indexFile}`, `${basePath}.md`];
+}
+
+function resolveGenericUrl(url: string, router: SiteRouterOptions): string[] {
+  const contentDir = router.contentDir;
+  const indexFile = router.indexFile ?? "index.md";
+  const urlPrefix = router.urlPrefix ?? "";
+
+  let path = url;
+  if (urlPrefix && path.startsWith(urlPrefix)) {
+    path = path.slice(urlPrefix.length);
+  }
+
+  const trimmed = path.replace(/\/$/, "").replace(/^\//, "");
+  const basePath = [contentDir, trimmed]
+    .filter((s): s is string => Boolean(s))
+    .join("/");
+
+  return [`${basePath}/${indexFile}`, `${basePath}.md`];
+}
+
+function resolveRoutedUrl(url: string, router: SiteRouterOptions): string[] {
+  if (router.preset === "starlight") {
+    return resolveStarlightUrl(url, router);
+  }
+  return resolveGenericUrl(url, router);
+}
+
 export function ref001(options?: Ref001Options): Rule {
   const excludeMatchers = options?.exclude?.map((p) => globMatch(`**/${p}`)) ?? [];
+  const siteRouter = options?.siteRouter;
 
   return {
     id: "REF-001",
@@ -25,21 +93,37 @@ export function ref001(options?: Ref001Options): Rule {
       const allPaths = new Set(context.documents.keys());
 
       for (const link of context.document.links) {
-        // Strip anchor fragment (e.g. ./file.md#section -> ./file.md)
         const urlWithoutAnchor = link.url.split("#")[0];
         if (!urlWithoutAnchor) {
           continue;
         }
 
-        // Strip leading ../ or ./ to match against exclude patterns
         const stripped = urlWithoutAnchor.replace(/^(\.\.?\/)+/, "");
         if (excludeMatchers.some((m) => m(stripped))) {
           continue;
         }
 
-        const resolved = resolve(dirname(context.filePath), urlWithoutAnchor);
+        // siteRouter resolution for absolute URLs (e.g. /docs/x/, /ja/docs/x/)
+        if (urlWithoutAnchor.startsWith("/") && siteRouter) {
+          const candidates = resolveRoutedUrl(urlWithoutAnchor, siteRouter);
+          const found = candidates.some((p) => {
+            const resolved = resolve(p);
+            return allPaths.has(resolved) || existsSync(resolved);
+          });
 
-        if (!allPaths.has(resolved) && !existsSync(resolved)) {
+          if (!found) {
+            context.report({
+              severity: "error",
+              message: `Link target "${link.url}" does not exist`,
+              line: link.line,
+            });
+          }
+          continue;
+        }
+
+        const resolvedPath = resolve(dirname(context.filePath), urlWithoutAnchor);
+
+        if (!allPaths.has(resolvedPath) && !existsSync(resolvedPath)) {
           context.report({
             severity: "error",
             message: `Link target "${link.url}" does not exist`,

--- a/packages/site/src/content/docs/docs/rules/ref-001.md
+++ b/packages/site/src/content/docs/docs/rules/ref-001.md
@@ -16,8 +16,57 @@ Renaming, deleting, or moving files is the most common way Markdown documents de
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `exclude` | string[] | — | Array of glob patterns whose link targets are excluded from validation |
+| `siteRouter` | object | — | Resolves routed URLs (e.g. `/docs/x/`) emitted by SSGs to real files |
 
 The rule works even with no options at all. Use `exclude` for cases where you intentionally link to documents or generated artifacts outside the `include` set.
+
+### `siteRouter` — resolving SSG routed URLs
+
+By default REF-001 resolves relative links (`./file.md`) as file system paths. SSGs like Astro Starlight emit **routed URLs** (`/docs/x/` or `/ja/docs/x/`) that don't correspond to literal file paths, so without `siteRouter` they are flagged as broken.
+
+| Sub-field | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `preset` | string | — | Known SSG preset. Currently `"starlight"` only |
+| `contentDir` | string | ✓ | Content directory (e.g. `"packages/site/src/content/docs"`) |
+| `defaultLocale` | string | — | Default locale identifier. Use `"root"` for Starlight's prefix-less root locale |
+| `locales` | string[] | — | Supported locale identifiers (e.g. `["root", "ja", "ko", "zh"]`) |
+| `urlPrefix` | string | — | (Generic, no preset) URL prefix to strip before resolving |
+| `indexFile` | string | — | Index file name to try first (default: `"index.md"`) |
+
+**Starlight (i18n) example:**
+
+```json
+{
+  "rule": "ref001",
+  "options": {
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
+
+`/docs/get-started/` resolves to `<contentDir>/docs/get-started/index.md` or `<contentDir>/docs/get-started.md`. `/ja/docs/get-started/` resolves to `<contentDir>/ja/docs/get-started/index.md`.
+
+**Generic (no preset) example:**
+
+```json
+{
+  "rule": "ref001",
+  "options": {
+    "siteRouter": {
+      "contentDir": "src/pages",
+      "urlPrefix": "/wiki",
+      "indexFile": "README.md"
+    }
+  }
+}
+```
+
+`/wiki/some-page/` resolves to `src/pages/some-page/README.md`.
 
 ## Bad example
 

--- a/packages/site/src/content/docs/ja/docs/rules/ref-001.md
+++ b/packages/site/src/content/docs/ja/docs/rules/ref-001.md
@@ -16,8 +16,57 @@ Markdown 内の相対リンク（`[text](./file.md)` の形式）が、実在す
 | フィールド | 型 | 必須 | 説明 |
 |----------|------|------|------|
 | `exclude` | string[] | — | リンク先の検証から除外するパスの glob 配列 |
+| `siteRouter` | object | — | SSG の routed URL（例: `/docs/x/`）を実ファイルに解決する設定 |
 
 オプション全体を省略しても動作します。`exclude` は外部のドキュメントや生成物のように、`include` の対象外だが意図的に存在しないファイルを参照する場合に使います。
+
+### `siteRouter` — SSG の routed URL 対応
+
+通常 REF-001 は `./file.md` のような相対リンクを file system path として解決しますが、Astro Starlight などの SSG が生成する **routed URL**（`/docs/x/` や `/ja/docs/x/`）はそのままでは file path として存在しないため、`siteRouter` を指定しないと broken link と判定されます。
+
+| サブフィールド | 型 | 必須 | 説明 |
+|--------------|------|------|------|
+| `preset` | string | — | 既知の SSG プリセット。現在は `"starlight"` のみ対応 |
+| `contentDir` | string | ✓ | コンテンツディレクトリ（例: `"packages/site/src/content/docs"`）|
+| `defaultLocale` | string | — | デフォルトロケール。Starlight の prefix なし root ロケールには `"root"` を指定 |
+| `locales` | string[] | — | サポートするロケールのリスト（例: `["root", "ja", "ko", "zh"]`）|
+| `urlPrefix` | string | — | (preset を使わない汎用設定) URL から取り除くプレフィックス |
+| `indexFile` | string | — | 最初に試す index ファイル名（既定: `"index.md"`）|
+
+**Starlight (i18n) の例:**
+
+```json
+{
+  "rule": "ref001",
+  "options": {
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
+
+`/docs/get-started/` は `<contentDir>/docs/get-started/index.md` か `<contentDir>/docs/get-started.md` に解決されます。`/ja/docs/get-started/` は `<contentDir>/ja/docs/get-started/index.md` に解決されます。
+
+**汎用設定（preset なし）の例:**
+
+```json
+{
+  "rule": "ref001",
+  "options": {
+    "siteRouter": {
+      "contentDir": "src/pages",
+      "urlPrefix": "/wiki",
+      "indexFile": "README.md"
+    }
+  }
+}
+```
+
+`/wiki/some-page/` は `src/pages/some-page/README.md` に解決されます。
 
 ## 違反例
 

--- a/packages/site/src/content/docs/ko/docs/integrations/ai-agents/mcp-server.md
+++ b/packages/site/src/content/docs/ko/docs/integrations/ai-agents/mcp-server.md
@@ -78,7 +78,7 @@ glob 패턴에 일치하는 파일을 `contextlint.config.json`의 설정으로 
 
 | 입력 | 타입 | 개요 |
 | --- | --- | --- |
-| `patterns` | string[](선택) | glob 패턴. 생략 시는 config의 `include`, 그것도 없으면 `["**/*.md"]` |
+| `patterns` | string[] (선택) | glob 패턴. 생략 시는 config의 `include`, 그것도 없으면 `["**/*.md"]` |
 | `configPath` | string(선택) | 설정 파일 경로. 생략 시는 부모 디렉터리를 거슬러 올라 자동 감지 |
 | `cwd` | string(선택) | 작업 디렉터리 |
 

--- a/packages/site/src/content/docs/ko/docs/rules/ref-001.md
+++ b/packages/site/src/content/docs/ko/docs/rules/ref-001.md
@@ -16,8 +16,57 @@ Markdown 내의 상대 링크(`[text](./file.md)` 형식)가 실재하는 파일
 | 필드 | 타입 | 필수 | 설명 |
 |----------|------|------|------|
 | `exclude` | string[] | — | 링크 대상의 검증에서 제외할 경로의 glob 배열 |
+| `siteRouter` | object | — | SSG의 routed URL(예: `/docs/x/`)을 실제 파일로 해결하는 설정 |
 
 옵션 전체를 생략해도 동작합니다. `exclude`는 외부 문서나 생성물처럼 `include`의 대상 외이지만 의도적으로 존재하지 않는 파일을 참조하는 경우에 사용합니다.
+
+### `siteRouter` — SSG의 routed URL 대응
+
+기본적으로 REF-001은 `./file.md` 같은 상대 링크를 file system 경로로 해결하지만, Astro Starlight 같은 SSG가 생성하는 **routed URL**(`/docs/x/` 또는 `/ja/docs/x/`)은 그대로는 file path로 존재하지 않으므로 `siteRouter`를 지정하지 않으면 broken link로 판정됩니다.
+
+| 서브필드 | 타입 | 필수 | 설명 |
+|--------------|------|------|------|
+| `preset` | string | — | 알려진 SSG 프리셋. 현재 `"starlight"`만 지원 |
+| `contentDir` | string | ✓ | 콘텐츠 디렉터리(예: `"packages/site/src/content/docs"`) |
+| `defaultLocale` | string | — | 기본 로케일. Starlight의 prefix 없는 root 로케일에는 `"root"` 지정 |
+| `locales` | string[] | — | 지원하는 로케일 목록(예: `["root", "ja", "ko", "zh"]`) |
+| `urlPrefix` | string | — | (preset을 사용하지 않는 범용 설정) URL에서 제거할 프리픽스 |
+| `indexFile` | string | — | 가장 먼저 시도할 index 파일명(기본값: `"index.md"`) |
+
+**Starlight (i18n) 예시:**
+
+```json
+{
+  "rule": "ref001",
+  "options": {
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
+
+`/docs/get-started/`는 `<contentDir>/docs/get-started/index.md` 또는 `<contentDir>/docs/get-started.md`로 해결됩니다. `/ja/docs/get-started/`는 `<contentDir>/ja/docs/get-started/index.md`로 해결됩니다.
+
+**범용 설정(preset 없음) 예시:**
+
+```json
+{
+  "rule": "ref001",
+  "options": {
+    "siteRouter": {
+      "contentDir": "src/pages",
+      "urlPrefix": "/wiki",
+      "indexFile": "README.md"
+    }
+  }
+}
+```
+
+`/wiki/some-page/`는 `src/pages/some-page/README.md`로 해결됩니다.
 
 ## 위반 예시
 

--- a/packages/site/src/content/docs/zh/docs/rules/ref-001.md
+++ b/packages/site/src/content/docs/zh/docs/rules/ref-001.md
@@ -16,8 +16,57 @@ description: 验证 Markdown 中的相对链接指向存在的文件。
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | `exclude` | string[] | — | 从链接目标验证中排除的路径 glob 数组 |
+| `siteRouter` | object | — | 将 SSG 的 routed URL（如 `/docs/x/`）解析为实际文件的配置 |
 
 省略全部选项也可工作。`exclude` 用于像外部文档或生成物那样不在 `include` 范围内、但被有意引用的文件。
+
+### `siteRouter` — SSG 的 routed URL 支持
+
+默认情况下 REF-001 把 `./file.md` 这类相对链接当作 file system 路径解析。但 Astro Starlight 等 SSG 生成的 **routed URL**（`/docs/x/` 或 `/ja/docs/x/`）作为 file path 并不存在，因此不指定 `siteRouter` 就会被判定为 broken link。
+
+| 子字段 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| `preset` | string | — | 已知的 SSG 预设。目前仅支持 `"starlight"` |
+| `contentDir` | string | ✓ | 内容目录（如 `"packages/site/src/content/docs"`） |
+| `defaultLocale` | string | — | 默认 locale。Starlight 无前缀的 root locale 指定为 `"root"` |
+| `locales` | string[] | — | 支持的 locale 列表（如 `["root", "ja", "ko", "zh"]`） |
+| `urlPrefix` | string | — | (不使用 preset 的通用配置) 从 URL 中剥离的前缀 |
+| `indexFile` | string | — | 最先尝试的 index 文件名（默认: `"index.md"`） |
+
+**Starlight (i18n) 示例:**
+
+```json
+{
+  "rule": "ref001",
+  "options": {
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
+
+`/docs/get-started/` 解析为 `<contentDir>/docs/get-started/index.md` 或 `<contentDir>/docs/get-started.md`。`/ja/docs/get-started/` 解析为 `<contentDir>/ja/docs/get-started/index.md`。
+
+**通用配置（无 preset）示例:**
+
+```json
+{
+  "rule": "ref001",
+  "options": {
+    "siteRouter": {
+      "contentDir": "src/pages",
+      "urlPrefix": "/wiki",
+      "indexFile": "README.md"
+    }
+  }
+}
+```
+
+`/wiki/some-page/` 解析为 `src/pages/some-page/README.md`。
 
 ## 违例
 

--- a/schema.json
+++ b/schema.json
@@ -337,6 +337,40 @@
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "Glob patterns for link targets to exclude from checking (e.g. [\"*.pdf\", \"external/**\"])."
+                  },
+                  "siteRouter": {
+                    "type": "object",
+                    "description": "Site router config for resolving routed URLs (e.g. Starlight URL convention).",
+                    "properties": {
+                      "preset": {
+                        "type": "string",
+                        "enum": ["starlight"],
+                        "description": "Preset for known SSGs. Currently supports: starlight. Omit for generic urlPrefix-based resolution."
+                      },
+                      "contentDir": {
+                        "type": "string",
+                        "description": "Directory containing the source Markdown files (e.g. \"packages/site/src/content/docs\")."
+                      },
+                      "defaultLocale": {
+                        "type": "string",
+                        "description": "Default locale identifier. Use \"root\" for Starlight's prefix-less root locale."
+                      },
+                      "locales": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "List of supported locale identifiers (e.g. [\"root\", \"ja\", \"ko\", \"zh\"])."
+                      },
+                      "urlPrefix": {
+                        "type": "string",
+                        "description": "(Generic, no preset) URL prefix to strip before resolving."
+                      },
+                      "indexFile": {
+                        "type": "string",
+                        "description": "Index file name to try first (default: \"index.md\")."
+                      }
+                    },
+                    "required": ["contentDir"],
+                    "additionalProperties": false
                   }
                 },
                 "additionalProperties": false

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll } from "bun:test";
+import { describe, it, expect, afterAll, beforeAll } from "bun:test";
 import { join, resolve } from "node:path";
 import {
   existsSync,
@@ -764,6 +764,90 @@ describe("E2E edge cases", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("Document Graph: 1 file");
     expect(result.stdout).toContain("0 edges");
+  });
+});
+
+// ===========================================================================
+// REF-001 siteRouter (Starlight preset) E2E
+// ===========================================================================
+
+describe("E2E REF-001 siteRouter (starlight preset)", () => {
+  const fixtureDir = join(fixturesDir, "starlight-site");
+  const configPath = join(fixtureDir, "contextlint.config.json");
+
+  // Build the config with an absolute contentDir at runtime, since the fixture
+  // path is environment-dependent.
+  beforeAll(() => {
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          include: ["content/docs/**/*.md"],
+          rules: [
+            {
+              rule: "ref001",
+              options: {
+                siteRouter: {
+                  preset: "starlight",
+                  contentDir: join(fixtureDir, "content", "docs"),
+                  defaultLocale: "root",
+                  locales: ["root", "ja"],
+                },
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+  });
+
+  afterAll(() => {
+    try {
+      rmSync(configPath, { force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it("detects only the intentional broken Starlight URL", () => {
+    const results = runFixtureLint(fixtureDir);
+    const violations = messagesFor(results, "REF-001");
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.message).toContain("/docs/missing-page/");
+  });
+
+  it("resolves root locale Starlight URLs to index.md files", () => {
+    // /docs/get-started/ → content/docs/docs/get-started/index.md
+    const results = runFixtureLint(fixtureDir);
+    const violations = messagesFor(results, "REF-001");
+    expect(
+      violations.filter((v) => v.message.includes("/docs/get-started/")),
+    ).toHaveLength(0);
+  });
+
+  it("resolves root locale URLs with .md fallback (no index.md)", () => {
+    // /docs/configuration/ → content/docs/docs/configuration.md (no index.md)
+    const results = runFixtureLint(fixtureDir);
+    const violations = messagesFor(results, "REF-001");
+    expect(
+      violations.filter((v) => v.message.includes("/docs/configuration/")),
+    ).toHaveLength(0);
+  });
+
+  it("resolves ja locale Starlight URLs", () => {
+    const results = runFixtureLint(fixtureDir);
+    const violations = messagesFor(results, "REF-001");
+    expect(
+      violations.filter((v) => v.message.includes("/ja/")),
+    ).toHaveLength(0);
+  });
+
+  it("loads all 4 fixture files via include pattern", () => {
+    const results = runFixtureLint(fixtureDir);
+    const fileCount = results.filter((r) => r.filePath !== "<project>").length;
+    expect(fileCount).toBe(4);
   });
 });
 

--- a/tests/e2e/fixtures/starlight-site/content/docs/docs/configuration.md
+++ b/tests/e2e/fixtures/starlight-site/content/docs/docs/configuration.md
@@ -1,0 +1,5 @@
+# Configuration
+
+Back to [Get Started](/docs/get-started/).
+
+This is an intentionally broken link for testing: [Missing Page](/docs/missing-page/).

--- a/tests/e2e/fixtures/starlight-site/content/docs/docs/get-started/index.md
+++ b/tests/e2e/fixtures/starlight-site/content/docs/docs/get-started/index.md
@@ -1,0 +1,5 @@
+# Get Started
+
+See [Configuration](/docs/configuration/) for setup details.
+
+For Japanese readers: [はじめに](/ja/docs/get-started/).

--- a/tests/e2e/fixtures/starlight-site/content/docs/ja/docs/configuration.md
+++ b/tests/e2e/fixtures/starlight-site/content/docs/ja/docs/configuration.md
@@ -1,0 +1,3 @@
+# 設定
+
+[はじめに](/ja/docs/get-started/) に戻る。

--- a/tests/e2e/fixtures/starlight-site/content/docs/ja/docs/get-started/index.md
+++ b/tests/e2e/fixtures/starlight-site/content/docs/ja/docs/get-started/index.md
@@ -1,0 +1,3 @@
+# はじめに
+
+詳しい設定は [Configuration](/ja/docs/configuration/) を参照してください。


### PR DESCRIPTION
## Summary

Implements #124 — REF-001 now resolves routed URLs from SSGs when the new `siteRouter` option is provided. Ships the `starlight` preset and a generic fallback. **Backwards-compatible**: existing users see no change.

- **REF-001 `siteRouter` option** — Zod schema + URL resolver + Starlight preset (root locale + locale-prefixed) + generic `urlPrefix` fallback
- **e2e fixture** `tests/e2e/fixtures/starlight-site/` — root locale + ja, multiple resolution patterns (`index.md` + `.md` fallback) + intentional broken link
- **Dogfooding**: root `contextlint.config.json` now lints the site docs with `siteRouter` and SEC-001 template enforcement (decisions / rules × 4 lang / graph-api × 4 lang / recipes × 4 lang). **280+ pages × 4 languages = 0 violations**
- **REF-001 docs** updated in all 4 languages with a new `siteRouter` section
- **`schema.json`** updated for the new option (resolves `Property siteRouter is not allowed`)
- **Parser bug fix** (bundled): `extractText()` was dropping `inlineCode` text from headings, so `## Foo (\`bar\`)` became `Foo ()` — preventing SEC-001 from matching backtick-containing section names. Fixed in `packages/core/src/parser.ts`

## Test coverage

| Layer | Pass | Coverage |
|-------|------|----------|
| Unit (`ref-001.test.ts`) | 30 (19 + 11 new) | Starlight preset (root + 3 locales), generic preset, `.md` fallback, anchor strip, regression test for omitted `siteRouter` |
| E2E (`e2e.test.ts`) | 105 (100 + 5 new) | `starlight-site` fixture with broken-link detection across locales |
| Core total | **596 pass** | No regression |

## Known follow-up (tracked in #124)

GRP-001 / GRP-002 / GRP-003 face the same routed-URL problem (orphan / circular / traceability detection on Starlight URLs). The `siteRouter` resolver should be lifted into a shared utility consumed by all cross-file rules in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)