### PR TITLE
fix(site): make author name link to koborin.ai

### DIFF
--- a/packages/site/src/components/WhyThisExists.astro
+++ b/packages/site/src/components/WhyThisExists.astro
@@ -26,8 +26,10 @@
         <div class="flex items-center gap-4 mt-12">
           <div class="w-12 h-px bg-ink"></div>
           <div>
-            <div class="font-display text-base" style="font-weight: 600;">Nozomi Koborinai</div>
-            <div class="font-mono text-[0.7rem] text-mute uppercase tracking-widest">Author · <a href="https://koborin.ai" class="link-mark text-ink">koborin.ai</a></div>
+            <div class="font-display text-base" style="font-weight: 600;">
+              <a href="https://koborin.ai" class="link-mark text-ink">Nozomi Koborinai</a>
+            </div>
+            <div class="font-mono text-[0.7rem] text-mute uppercase tracking-widest">Author</div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

The `// ORIGIN` section in `packages/site/src/components/WhyThisExists.astro` had an awkward author byline:

**Before**: The name "Nozomi Koborinai" was plain text, with `Author · koborin.ai` below it — the role and the site URL juxtaposed with a middle dot, making it look like "Author" and "koborin.ai" were peer entities.

**After**: The name "Nozomi Koborinai" itself becomes the link to `https://koborin.ai`, and `Author` stands alone as a role label.

```diff
- Nozomi Koborinai
- Author · koborin.ai

+ Nozomi Koborinai          ← link to koborin.ai
+ Author                     ← role only
```

This makes the relationship explicit — Author is the person; the link target is their personal site. Matches the Footer's `Made by Nozomi Koborinai` (LinkedIn link) pattern, and the user-identity rule (the visible link text is the full name; the URL is `koborin.ai`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)