### PR TITLE
fix(site): mention Agent Skills alongside MCP / LSP

### DIFF
--- a/packages/site/src/components/Integrations.astro
+++ b/packages/site/src/components/Integrations.astro
@@ -7,7 +7,7 @@ const groups = [
   },
   {
     title: "AI assistants",
-    proto: "via MCP",
+    proto: "via MCP / Skills",
     tools: ["Claude Code", "Cursor Agent", "Cline", "Codex", "Windsurf", "Gemini CLI", "GitHub Copilot", "…and more"],
   },
   {

--- a/packages/site/src/components/ThreeLayer.astro
+++ b/packages/site/src/components/ThreeLayer.astro
@@ -91,8 +91,9 @@ const layers = [
 
     <p class="mt-12 max-w-2xl text-sm text-mute font-mono">
       <span class="text-accent">[ref:proto]</span> Built on Model Context
-      Protocol (MCP) and Language Server Protocol (LSP). Works with any
-      compatible client.
+      Protocol (MCP), Language Server Protocol (LSP), and
+      <a href="https://agentskills.io" class="link-mark text-ink">agentskills.io</a>.
+      Works with any compatible host.
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Summary

The LP previously referenced only Model Context Protocol and the Language Server Protocol when describing AI agent integration — agentskills.io and the `gh skill install` workflow appeared only in the Quick Start lane, not in the protocol-level explanation.

- **ThreeLayer.astro**: extend the `[ref:proto]` note to list MCP, LSP, **and agentskills.io**. `compatible client` → `compatible host` since Skills are a host concern
- **Integrations.astro**: AI assistants group proto label changes from `via MCP` to `via MCP / Skills` to reflect both routes

The tool list itself is unchanged — the same hosts (Claude Code, Cursor Agent, Cline, Codex, Windsurf, Gemini CLI, GitHub Copilot) participate through both MCP and Skills, depending on what the host implements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)