### PR TITLE
docs(rules): document siteRouter on GRP-002 and GRP-003

### DIFF
--- a/packages/site/src/content/docs/docs/rules/grp-002.md
+++ b/packages/site/src/content/docs/docs/rules/grp-002.md
@@ -19,8 +19,38 @@ A cycle where document A references B, B references C, and C references A cannot
 |-------|------|----------|-------------|
 | `files` | string | — | Glob of files included in cycle detection. If omitted, every document is included |
 | `exclude` | string[] | — | Array of globs for files to exclude from the graph |
+| `siteRouter` | object | — | Resolves routed URLs (e.g. `/docs/x/`) so cycle detection can follow links emitted by SSGs like Starlight |
 
 The rule works even with no options at all. Use `exclude` to skip files that intentionally hold links in multiple directions, such as table-of-contents pages or index files.
+
+### `siteRouter` — resolving SSG routed URLs
+
+Without `siteRouter`, absolute URLs like `/docs/x/` are skipped during graph construction, so cycles that pass through SSG-routed links go undetected. The shape is identical to [REF-001](/docs/rules/ref-001/)'s `siteRouter`.
+
+| Sub-field | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `preset` | string | — | Known SSG preset. Currently `"starlight"` only |
+| `contentDir` | string | ✓ | Content directory (e.g. `"packages/site/src/content/docs"`) |
+| `defaultLocale` | string | — | Default locale identifier. Use `"root"` for Starlight's prefix-less root locale |
+| `locales` | string[] | — | Supported locale identifiers (e.g. `["root", "ja", "ko", "zh"]`) |
+| `urlPrefix` | string | — | (Generic, no preset) URL prefix to strip before resolving |
+| `indexFile` | string | — | Index file name to try first (default: `"index.md"`) |
+
+**Starlight (i18n) example:**
+
+```json
+{
+  "rule": "grp002",
+  "options": {
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
 
 ## Bad example
 

--- a/packages/site/src/content/docs/docs/rules/grp-003.md
+++ b/packages/site/src/content/docs/docs/rules/grp-003.md
@@ -19,8 +19,40 @@ Renaming a file, moving it to another directory, or creating a new file without 
 |-------|------|----------|-------------|
 | `files` | string | — | Glob of files considered for orphan detection. If omitted, every document is considered |
 | `entryPoints` | string[] | — | Array of globs treated as entry points and excluded from orphan detection |
+| `siteRouter` | object | — | Resolves routed URLs (e.g. `/docs/x/`) so incoming references via SSG-emitted URLs are counted |
 
 Each pattern in `entryPoints` is matched both against the full path and against the basename of each file. `README.md` (basename) and `docs/README.md` (full path) both work.
+
+### `siteRouter` — resolving SSG routed URLs
+
+Without `siteRouter`, incoming references that use absolute URLs like `/docs/x/` aren't counted, so any document only reached via SSG-routed links is incorrectly flagged as an orphan. The shape is identical to [REF-001](/docs/rules/ref-001/)'s `siteRouter`.
+
+| Sub-field | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `preset` | string | — | Known SSG preset. Currently `"starlight"` only |
+| `contentDir` | string | ✓ | Content directory (e.g. `"packages/site/src/content/docs"`) |
+| `defaultLocale` | string | — | Default locale identifier. Use `"root"` for Starlight's prefix-less root locale |
+| `locales` | string[] | — | Supported locale identifiers (e.g. `["root", "ja", "ko", "zh"]`) |
+| `urlPrefix` | string | — | (Generic, no preset) URL prefix to strip before resolving |
+| `indexFile` | string | — | Index file name to try first (default: `"index.md"`) |
+
+**Starlight (i18n) example:**
+
+```json
+{
+  "rule": "grp003",
+  "options": {
+    "files": "packages/site/src/content/docs/**/*.md",
+    "entryPoints": ["docs/*/index.md"],
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
 
 ## Bad example
 

--- a/packages/site/src/content/docs/ja/docs/rules/grp-002.md
+++ b/packages/site/src/content/docs/ja/docs/rules/grp-002.md
@@ -19,8 +19,38 @@ description: ドキュメント間のリンクで循環参照が発生してい�
 |----------|------|------|------|
 | `files` | string | — | 循環検出の対象とするファイルの glob。未指定なら全ドキュメント |
 | `exclude` | string[] | — | グラフから除外するファイルの glob 配列 |
+| `siteRouter` | object | — | Starlight など SSG が生成する routed URL（例: `/docs/x/`）を解決し、循環検出がそれらのリンクを辿れるようにする |
 
 オプション全体を省略しても動作します。`exclude` は、目次ファイルや index ファイルのように複数方向のリンクを意図的に持つファイルを除外する用途で使います。
+
+### `siteRouter` — SSG の routed URL 対応
+
+`siteRouter` を指定しないと、`/docs/x/` のような絶対 URL はグラフ構築時にスキップされ、SSG が生成するリンクを経由する循環は検出されません。指定可能なフィールドは [REF-001](/ja/docs/rules/ref-001/) の `siteRouter` と同一です。
+
+| サブフィールド | 型 | 必須 | 説明 |
+|--------------|------|------|------|
+| `preset` | string | — | 既知の SSG プリセット。現在は `"starlight"` のみ対応 |
+| `contentDir` | string | ✓ | コンテンツディレクトリ（例: `"packages/site/src/content/docs"`）|
+| `defaultLocale` | string | — | デフォルトロケール。Starlight の prefix なし root ロケールには `"root"` を指定 |
+| `locales` | string[] | — | サポートするロケールのリスト（例: `["root", "ja", "ko", "zh"]`）|
+| `urlPrefix` | string | — | (preset を使わない汎用設定) URL から取り除くプレフィックス |
+| `indexFile` | string | — | 最初に試す index ファイル名（既定: `"index.md"`）|
+
+**Starlight (i18n) の例:**
+
+```json
+{
+  "rule": "grp002",
+  "options": {
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
 
 ## 違反例
 

--- a/packages/site/src/content/docs/ja/docs/rules/grp-003.md
+++ b/packages/site/src/content/docs/ja/docs/rules/grp-003.md
@@ -19,8 +19,40 @@ description: どのドキュメントからも参照されていない孤立し�
 |----------|------|------|------|
 | `files` | string | — | 孤立判定の対象とするファイルの glob。未指定なら全ドキュメント |
 | `entryPoints` | string[] | — | 起点ドキュメントとみなして孤立判定から除外する glob 配列 |
+| `siteRouter` | object | — | Starlight など SSG が生成する routed URL（例: `/docs/x/`）を解決し、SSG 経由の被参照もカウントできるようにする |
 
 `entryPoints` の各パターンは、対象ファイルのパスとファイル名（basename）の両方に対して照合されます。`README.md` のようにベース名で書いても、`docs/README.md` のようにパスで書いても機能します。
+
+### `siteRouter` — SSG の routed URL 対応
+
+`siteRouter` を指定しないと、`/docs/x/` のような絶対 URL での被参照がカウントされず、SSG 経由でしか辿られないドキュメントが誤って孤立扱いされます。指定可能なフィールドは [REF-001](/ja/docs/rules/ref-001/) の `siteRouter` と同一です。
+
+| サブフィールド | 型 | 必須 | 説明 |
+|--------------|------|------|------|
+| `preset` | string | — | 既知の SSG プリセット。現在は `"starlight"` のみ対応 |
+| `contentDir` | string | ✓ | コンテンツディレクトリ（例: `"packages/site/src/content/docs"`）|
+| `defaultLocale` | string | — | デフォルトロケール。Starlight の prefix なし root ロケールには `"root"` を指定 |
+| `locales` | string[] | — | サポートするロケールのリスト（例: `["root", "ja", "ko", "zh"]`）|
+| `urlPrefix` | string | — | (preset を使わない汎用設定) URL から取り除くプレフィックス |
+| `indexFile` | string | — | 最初に試す index ファイル名（既定: `"index.md"`）|
+
+**Starlight (i18n) の例:**
+
+```json
+{
+  "rule": "grp003",
+  "options": {
+    "files": "packages/site/src/content/docs/**/*.md",
+    "entryPoints": ["docs/*/index.md"],
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
 
 ## 違反例
 

--- a/packages/site/src/content/docs/ko/docs/rules/grp-002.md
+++ b/packages/site/src/content/docs/ko/docs/rules/grp-002.md
@@ -19,8 +19,38 @@ description: 문서 간의 링크에서 순환 참조가 발생하지 않았는�
 |----------|------|------|------|
 | `files` | string | — | 순환 검출의 대상으로 할 파일의 glob. 미지정이면 모든 문서 |
 | `exclude` | string[] | — | 그래프에서 제외할 파일의 glob 배열 |
+| `siteRouter` | object | — | Starlight 같은 SSG가 생성하는 routed URL(예: `/docs/x/`)을 해결하여 순환 검출이 그 링크를 따라갈 수 있게 함 |
 
 옵션 전체를 생략해도 동작합니다. `exclude`는 목차 파일이나 index 파일처럼 여러 방향의 링크를 의도적으로 가지는 파일을 제외할 용도로 사용합니다.
+
+### `siteRouter` — SSG의 routed URL 대응
+
+`siteRouter`를 지정하지 않으면, `/docs/x/` 같은 절대 URL은 그래프 구축 시 건너뛰어지므로, SSG가 생성하는 링크를 거치는 순환은 검출되지 않습니다. 지정 가능한 필드는 [REF-001](/ko/docs/rules/ref-001/)의 `siteRouter`와 동일합니다.
+
+| 서브필드 | 타입 | 필수 | 설명 |
+|--------------|------|------|------|
+| `preset` | string | — | 알려진 SSG 프리셋. 현재 `"starlight"`만 지원 |
+| `contentDir` | string | ✓ | 콘텐츠 디렉터리(예: `"packages/site/src/content/docs"`) |
+| `defaultLocale` | string | — | 기본 로케일. Starlight의 prefix 없는 root 로케일에는 `"root"` 지정 |
+| `locales` | string[] | — | 지원하는 로케일 목록(예: `["root", "ja", "ko", "zh"]`) |
+| `urlPrefix` | string | — | (preset을 사용하지 않는 범용 설정) URL에서 제거할 프리픽스 |
+| `indexFile` | string | — | 가장 먼저 시도할 index 파일명(기본값: `"index.md"`) |
+
+**Starlight (i18n) 예시:**
+
+```json
+{
+  "rule": "grp002",
+  "options": {
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
 
 ## 위반 예시
 

--- a/packages/site/src/content/docs/ko/docs/rules/grp-003.md
+++ b/packages/site/src/content/docs/ko/docs/rules/grp-003.md
@@ -19,8 +19,40 @@ description: 어느 문서에서도 참조되지 않은 고립된 파일을 검�
 |----------|------|------|------|
 | `files` | string | — | 고립 판정의 대상으로 할 파일의 glob. 미지정이면 모든 문서 |
 | `entryPoints` | string[] | — | 기점 문서로 간주하여 고립 판정에서 제외할 glob 배열 |
+| `siteRouter` | object | — | Starlight 같은 SSG가 생성하는 routed URL(예: `/docs/x/`)을 해결하여 SSG 경유의 인커밍 참조도 카운트할 수 있게 함 |
 
 `entryPoints`의 각 패턴은, 대상 파일의 경로와 파일명(basename) 양쪽에 대해 대조됩니다. `README.md`처럼 베이스 이름으로 써도, `docs/README.md`처럼 경로로 써도 기능합니다.
+
+### `siteRouter` — SSG의 routed URL 대응
+
+`siteRouter`를 지정하지 않으면, `/docs/x/` 같은 절대 URL을 통한 인커밍 참조가 카운트되지 않아, SSG 경유로만 도달 가능한 문서가 잘못 고립으로 판정됩니다. 지정 가능한 필드는 [REF-001](/ko/docs/rules/ref-001/)의 `siteRouter`와 동일합니다.
+
+| 서브필드 | 타입 | 필수 | 설명 |
+|--------------|------|------|------|
+| `preset` | string | — | 알려진 SSG 프리셋. 현재 `"starlight"`만 지원 |
+| `contentDir` | string | ✓ | 콘텐츠 디렉터리(예: `"packages/site/src/content/docs"`) |
+| `defaultLocale` | string | — | 기본 로케일. Starlight의 prefix 없는 root 로케일에는 `"root"` 지정 |
+| `locales` | string[] | — | 지원하는 로케일 목록(예: `["root", "ja", "ko", "zh"]`) |
+| `urlPrefix` | string | — | (preset을 사용하지 않는 범용 설정) URL에서 제거할 프리픽스 |
+| `indexFile` | string | — | 가장 먼저 시도할 index 파일명(기본값: `"index.md"`) |
+
+**Starlight (i18n) 예시:**
+
+```json
+{
+  "rule": "grp003",
+  "options": {
+    "files": "packages/site/src/content/docs/**/*.md",
+    "entryPoints": ["docs/*/index.md"],
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
 
 ## 위반 예시
 

--- a/packages/site/src/content/docs/zh/docs/rules/grp-002.md
+++ b/packages/site/src/content/docs/zh/docs/rules/grp-002.md
@@ -19,8 +19,38 @@ description: 验证文档间链接中不存在循环引用。
 |------|------|------|------|
 | `files` | string | — | 循环检测对象的文件 glob。未指定则覆盖所有文档 |
 | `exclude` | string[] | — | 从图中排除的文件 glob 数组 |
+| `siteRouter` | object | — | 解析 Starlight 等 SSG 生成的 routed URL(如 `/docs/x/`),让循环检测能沿这些链接遍历 |
 
 省略全部选项也可工作。`exclude` 用于排除像目录文件或 index 文件那样有意持有多向链接的文件。
+
+### `siteRouter` — SSG 的 routed URL 支持
+
+不指定 `siteRouter` 时,`/docs/x/` 这类绝对 URL 在构建图时会被跳过,因此经由 SSG 生成链接的循环不会被检出。可用字段与 [REF-001](/zh/docs/rules/ref-001/) 的 `siteRouter` 完全相同。
+
+| 子字段 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| `preset` | string | — | 已知的 SSG 预设。目前仅支持 `"starlight"` |
+| `contentDir` | string | ✓ | 内容目录（如 `"packages/site/src/content/docs"`） |
+| `defaultLocale` | string | — | 默认 locale。Starlight 无前缀的 root locale 指定为 `"root"` |
+| `locales` | string[] | — | 支持的 locale 列表（如 `["root", "ja", "ko", "zh"]`） |
+| `urlPrefix` | string | — | (不使用 preset 的通用配置) 从 URL 中剥离的前缀 |
+| `indexFile` | string | — | 最先尝试的 index 文件名（默认: `"index.md"`） |
+
+**Starlight (i18n) 示例:**
+
+```json
+{
+  "rule": "grp002",
+  "options": {
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
 
 ## 违例
 

--- a/packages/site/src/content/docs/zh/docs/rules/grp-003.md
+++ b/packages/site/src/content/docs/zh/docs/rules/grp-003.md
@@ -19,8 +19,40 @@ description: 检测未被任何文档引用的孤立文件。
 |------|------|------|------|
 | `files` | string | — | 孤立判定对象的文件 glob。未指定则覆盖所有文档 |
 | `entryPoints` | string[] | — | 视为起点文档而从孤立判定中排除的 glob 数组 |
+| `siteRouter` | object | — | 解析 Starlight 等 SSG 生成的 routed URL(如 `/docs/x/`),从而能够计入经由 SSG 链接的入度 |
 
 `entryPoints` 的每个模式都会与对象文件的路径和文件名(basename)双方进行匹配。无论用 `README.md` 这样的 basename 书写,还是用 `docs/README.md` 这样的路径书写都生效。
+
+### `siteRouter` — SSG 的 routed URL 支持
+
+不指定 `siteRouter` 时,`/docs/x/` 这类绝对 URL 的入度不会被计入,因此只能经由 SSG 链接到达的文档会被错误判定为孤立。可用字段与 [REF-001](/zh/docs/rules/ref-001/) 的 `siteRouter` 完全相同。
+
+| 子字段 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| `preset` | string | — | 已知的 SSG 预设。目前仅支持 `"starlight"` |
+| `contentDir` | string | ✓ | 内容目录（如 `"packages/site/src/content/docs"`） |
+| `defaultLocale` | string | — | 默认 locale。Starlight 无前缀的 root locale 指定为 `"root"` |
+| `locales` | string[] | — | 支持的 locale 列表（如 `["root", "ja", "ko", "zh"]`） |
+| `urlPrefix` | string | — | (不使用 preset 的通用配置) 从 URL 中剥离的前缀 |
+| `indexFile` | string | — | 最先尝试的 index 文件名（默认: `"index.md"`） |
+
+**Starlight (i18n) 示例:**
+
+```json
+{
+  "rule": "grp003",
+  "options": {
+    "files": "packages/site/src/content/docs/**/*.md",
+    "entryPoints": ["docs/*/index.md"],
+    "siteRouter": {
+      "preset": "starlight",
+      "contentDir": "packages/site/src/content/docs",
+      "defaultLocale": "root",
+      "locales": ["root", "ja", "ko", "zh"]
+    }
+  }
+}
+```
 
 ## 违例
 


### PR DESCRIPTION
## Summary

PR #128 added the `siteRouter` option to GRP-002 (cycle detection) and GRP-003 (orphan detection), but only REF-001's docs page mentioned it. This PR brings the GRP rule pages in sync across en/ja/ko/zh.

- Adds a `siteRouter` row to each rule's Options table.
- Adds a level-3 `siteRouter` subsection with the full sub-field reference and a Starlight (i18n) example scoped to each rule.
- Cross-links to REF-001's `siteRouter` section so the shape of the option stays a single source of truth.

The new subsection sits at heading level 3, so the SEC-001 template enforcement on `docs/**/rules/*-*.md` is unaffected. `bun run lint:docs` reports zero violations and the site builds 283 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)