### PR TITLE
docs(readme): add Skill-first lane to Quick Start

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -37,21 +37,23 @@ contextlint は、構造化された Markdown のための
 
 ## クイックスタート
 
-CLI をインストール:
+**AI 支援セットアップ（推奨）** — Claude Code、Cursor、Codex、Gemini CLI、
+GitHub Copilot など [Agent Skills](https://agentskills.io) 互換クライアント向け。
+GitHub CLI **v2.90 以上**が必要です:
+
+```sh
+gh skill install nozomi-koborinai/contextlint contextlint-init
+```
+
+その後、エージェントに「contextlint をセットアップして」と指示してください。
+Skill がリポジトリのレイアウトを検出し、ルールを推測し、CLI をインストールし、
+`contextlint.config.json` を生成します。
+
+**手動セットアップ**:
 
 ```bash
 npm install -D @contextlint/cli
-```
-
-設定ファイルを対話形式で生成:
-
-```bash
 npx contextlint init
-```
-
-実行:
-
-```bash
 npx contextlint
 ```
 
@@ -66,9 +68,6 @@ docs/design.md
 
 1 error, 1 warning in 2 files
 ```
-
-`gh skill install` を使った AI 支援セットアップは
-[Get Started](https://contextlint.dev/ja/docs/get-started/) を参照してください。
 
 ## ルール
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,21 +36,23 @@ contextlint는 구조화된 Markdown을 위한
 
 ## 빠른 시작
 
-CLI 설치:
+**AI 지원 셋업(권장)** — Claude Code, Cursor, Codex, Gemini CLI,
+GitHub Copilot 등 [Agent Skills](https://agentskills.io) 호환 클라이언트용.
+GitHub CLI **v2.90 이상** 필요:
+
+```sh
+gh skill install nozomi-koborinai/contextlint contextlint-init
+```
+
+이후 에이전트에게 "contextlint 셋업해줘"라고 지시하세요.
+Skill이 저장소 레이아웃을 감지하고, 규칙을 추론하고, CLI를 설치하고,
+`contextlint.config.json`을 작성해 줍니다.
+
+**수동 셋업**:
 
 ```bash
 npm install -D @contextlint/cli
-```
-
-대화식으로 설정 파일 생성:
-
-```bash
 npx contextlint init
-```
-
-실행:
-
-```bash
 npx contextlint
 ```
 
@@ -65,9 +67,6 @@ docs/design.md
 
 1 error, 1 warning in 2 files
 ```
-
-`gh skill install`을 사용한 AI 지원 셋업은
-[Get Started](https://contextlint.dev/ko/docs/get-started/)를 참조하세요.
 
 ## 규칙
 

--- a/README.md
+++ b/README.md
@@ -37,21 +37,23 @@ Markdown. No AI, no cost, CI-friendly.
 
 ## Quick Start
 
-Install the CLI:
+**AI-assisted (recommended)** — for Claude Code, Cursor, Codex, Gemini CLI,
+GitHub Copilot, and any [Agent Skills](https://agentskills.io)-compatible
+client. Requires GitHub CLI **v2.90+**:
+
+```sh
+gh skill install nozomi-koborinai/contextlint contextlint-init
+```
+
+Then ask your agent to "set up contextlint". The skill detects your repo
+layout, infers rules, installs the CLI, and writes `contextlint.config.json`
+for you.
+
+**Manual setup**:
 
 ```bash
 npm install -D @contextlint/cli
-```
-
-Generate a config interactively:
-
-```bash
 npx contextlint init
-```
-
-Run:
-
-```bash
 npx contextlint
 ```
 
@@ -66,9 +68,6 @@ docs/design.md
 
 1 error, 1 warning in 2 files
 ```
-
-For AI-assisted setup with `gh skill install`, see
-[Get Started](https://contextlint.dev/docs/get-started/).
 
 ## Rules
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -33,21 +33,23 @@ contextlint 为结构化 Markdown 提供
 
 ## 快速开始
 
-安装 CLI：
+**AI 辅助安装（推荐）** — 适用于 Claude Code、Cursor、Codex、Gemini CLI、
+GitHub Copilot 以及任何 [Agent Skills](https://agentskills.io) 兼容客户端。
+需要 GitHub CLI **v2.90 及以上**：
+
+```sh
+gh skill install nozomi-koborinai/contextlint contextlint-init
+```
+
+随后让你的 Agent「设置 contextlint」。
+Skill 会检测仓库布局、推断规则、安装 CLI 并生成
+`contextlint.config.json`。
+
+**手动安装**：
 
 ```bash
 npm install -D @contextlint/cli
-```
-
-交互式生成配置文件：
-
-```bash
 npx contextlint init
-```
-
-运行：
-
-```bash
 npx contextlint
 ```
 
@@ -62,9 +64,6 @@ docs/design.md
 
 1 error, 1 warning in 2 files
 ```
-
-通过 `gh skill install` 进行 AI 辅助初始化的步骤，请参见
-[Get Started](https://contextlint.dev/zh/docs/get-started/)。
 
 ## 规则
 


### PR DESCRIPTION
## Summary

After the README trim landed in #130, the AI-assisted setup was only a trailing pointer to docs. Surface it as the **primary** Quick Start lane so a GitHub visitor sees the recommended path first.

- **AI-assisted (recommended)** — one shot \`gh skill install nozomi-koborinai/contextlint contextlint-init\` followed by an agent prompt. Notes the GitHub CLI **v2.90+** floor.
- **Manual setup** — same three commands as before, compressed into one block.

Both lanes share the sample output. Applied across en/ja/ko/zh.

## Verification

- \`bunx markdownlint-cli2 "README*.md"\` — 0 errors
- All four READMEs stay at ~120 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)