### PR TITLE
chore: relicense from MIT to Apache-2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Nozomi Koborinai
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept and charge a
+      fee for, acceptance of support, warranty, indemnity, or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may act only on Your
+      own behalf and on Your sole responsibility, not on behalf of any
+      other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nozomi Koborinai
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+contextlint
+Copyright 2026 Nozomi Koborinai
+
+This product includes software developed by Nozomi Koborinai.

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,7 +9,7 @@
 [![mcp-server downloads](https://img.shields.io/npm/dm/@contextlint/mcp-server.svg?label=mcp-server%20downloads)](https://www.npmjs.com/package/@contextlint/mcp-server)
 [![lsp-server downloads](https://img.shields.io/npm/dm/@contextlint/lsp-server.svg?label=lsp-server%20downloads)](https://www.npmjs.com/package/@contextlint/lsp-server)
 [![CI](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 🌐 [English](README.md) | [中文](README.zh.md) | [한국어](README.ko.md)
 
@@ -118,4 +118,4 @@ contextlint は **21 のルール**を 7 カテゴリで提供します:
 
 ## ライセンス
 
-[MIT](LICENSE)
+[Apache 2.0](LICENSE)

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,7 +9,7 @@
 [![mcp-server downloads](https://img.shields.io/npm/dm/@contextlint/mcp-server.svg?label=mcp-server%20downloads)](https://www.npmjs.com/package/@contextlint/mcp-server)
 [![lsp-server downloads](https://img.shields.io/npm/dm/@contextlint/lsp-server.svg?label=lsp-server%20downloads)](https://www.npmjs.com/package/@contextlint/lsp-server)
 [![CI](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 🌐 [English](README.md) | [日本語](README.ja.md) | [中文](README.zh.md)
 
@@ -117,4 +117,4 @@ contextlint는 **21개 규칙**을 7개 카테고리로 제공합니다:
 
 ## 라이선스
 
-[MIT](LICENSE)
+[Apache 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![mcp-server downloads](https://img.shields.io/npm/dm/@contextlint/mcp-server.svg?label=mcp-server%20downloads)](https://www.npmjs.com/package/@contextlint/mcp-server)
 [![lsp-server downloads](https://img.shields.io/npm/dm/@contextlint/lsp-server.svg?label=lsp-server%20downloads)](https://www.npmjs.com/package/@contextlint/lsp-server)
 [![CI](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 🌐 [日本語](README.ja.md) | [中文](README.zh.md) | [한국어](README.ko.md)
 
@@ -118,4 +118,4 @@ For commands beyond `lint` (`init`, `impact`, `slice`, `graph`, `compile`,
 
 ## License
 
-[MIT](LICENSE)
+[Apache 2.0](LICENSE)

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,7 @@
 [![mcp-server downloads](https://img.shields.io/npm/dm/@contextlint/mcp-server.svg?label=mcp-server%20downloads)](https://www.npmjs.com/package/@contextlint/mcp-server)
 [![lsp-server downloads](https://img.shields.io/npm/dm/@contextlint/lsp-server.svg?label=lsp-server%20downloads)](https://www.npmjs.com/package/@contextlint/lsp-server)
 [![CI](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/contextlint/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 
@@ -114,4 +114,4 @@ contextlint 提供 **21 条规则**，分为 7 个类别：
 
 ## 许可证
 
-[MIT](LICENSE)
+[Apache 2.0](LICENSE)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -66,4 +66,4 @@ See the [main repository](https://github.com/nozomi-koborinai/contextlint) for t
 
 ## License
 
-[MIT](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)
+[Apache 2.0](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,5 +34,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -76,4 +76,4 @@ See the [main repository](https://github.com/nozomi-koborinai/contextlint) for t
 
 ## License
 
-[MIT](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)
+[Apache 2.0](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "glob": "^13.0.6",
     "picomatch": "^4.0.3",

--- a/packages/lsp-server/README.md
+++ b/packages/lsp-server/README.md
@@ -34,4 +34,4 @@ for editor-specific setup snippets (Neovim, Helix, JetBrains).
 
 ## License
 
-[MIT](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)
+[Apache 2.0](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)

--- a/packages/lsp-server/package.json
+++ b/packages/lsp-server/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -45,4 +45,4 @@ For Claude Desktop on macOS, the config lives at `~/Library/Application Support/
 
 ## License
 
-[MIT](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)
+[Apache 2.0](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -32,5 +32,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -39,4 +39,4 @@ in the main repository.
 
 ## License
 
-[MIT](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)
+[Apache 2.0](https://github.com/nozomi-koborinai/contextlint/blob/main/LICENSE)

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -48,5 +48,5 @@
   "devDependencies": {
     "@types/vscode": "^1.82.0"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/skills/contextlint-fix/SKILL.md
+++ b/skills/contextlint-fix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: contextlint-fix
 description: Run contextlint over the project's structured Markdown and fix the violations it detects. Use this skill whenever the user asks to fix lint errors, clean up docs, repair broken Markdown links, or after bulk edits to documentation (especially AI-generated specs/ADRs) — even if they don't explicitly mention contextlint by name. Handles broken cross-references, missing required sections, empty table cells, leftover placeholders (TODO/TBD), and circular dependency references across the documentation graph. Reach for this any time the user mentions doc integrity, broken refs, or wants their Markdown checked.
-license: MIT
+license: Apache-2.0
 compatibility: Requires the @contextlint/cli npm package available in the project (will be invoked via npx). Network access only needed if installing the CLI.
 metadata:
   homepage: https://contextlint.dev

--- a/skills/contextlint-impact/SKILL.md
+++ b/skills/contextlint-impact/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: contextlint-impact
 description: Analyze the impact of changing or deleting a Markdown document by leveraging contextlint's Context Graph. Use this skill whenever the user asks "what breaks if I change X?", "what depends on this doc?", "is it safe to delete this file?", or wants to plan a refactor / understand cross-doc dependencies — even if they don't mention contextlint by name. Detects direct vs transitive impact, identifies orphan docs, and surfaces hidden dependencies that grep alone can't find. Built on contextlint's deterministic graph engine — same input, same answer.
-license: MIT
+license: Apache-2.0
 compatibility: Requires the @contextlint/cli npm package available in the project (will be invoked via npx) and a configured contextlint.config.json with cross-file rules (`ref001`, `grp002`) enabled.
 metadata:
   homepage: https://contextlint.dev

--- a/skills/contextlint-init/SKILL.md
+++ b/skills/contextlint-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: contextlint-init
 description: Bootstrap contextlint into a repository. Use this skill whenever the user wants to set up, install, initialize, or configure contextlint — even if they only say "lint setup", "doc integrity check", or "set up Markdown linting" without naming contextlint by name. Detects the package manager (bun/npm/pnpm/yarn), scans the repo's actual doc layout (no hardcoded `docs/` assumption), infers a rule set tailored to the project's structure (ADR style, spec style, table-heavy, etc.), installs `@contextlint/cli`, and writes `contextlint.config.json`. Also handles existing contextlint setups and offers optional GitHub Actions workflow + README scaffolding.
-license: MIT
+license: Apache-2.0
 compatibility: Requires bun, npm, pnpm, or yarn for installing @contextlint/cli. Network access needed to fetch the package from npm.
 metadata:
   homepage: https://contextlint.dev


### PR DESCRIPTION
## Summary

- Switch the project license from MIT to Apache-2.0 across `LICENSE`, all `package.json` license fields, all package READMEs, the four top-level README translations, and the published `skills/*/SKILL.md` frontmatter.
- Add a `NOTICE` file as required by Apache-2.0 attribution.
- Motivation: gain the explicit trademark clause (Section 6) and patent grant that MIT lacks, to better protect the `contextlint` name.